### PR TITLE
feat: multi-agent PR review system

### DIFF
--- a/.agents/skills/evaluate-review/SKILL.md
+++ b/.agents/skills/evaluate-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: evaluate-review
+description: Evaluates the output of the 3 reviewer sub-agents for a PR, synthesizes findings into a Fix-task comment, and applies approved or needs-fix labels. Invoked by the Orchestrator after all reviewers have posted.
+---
+
+# evaluate-review
+
+## When to Use
+
+Invoke this skill when you are acting as the **Evaluator** in the multi-agent PR review system. The Evaluator is called by the Orchestrator after the Architecture, Spec, and Test reviewers have all posted their comments on a PR.
+
+## Step-by-Step Evaluation Procedure
+
+### Step 1 — Read All Review Comments
+
+```bash
+gh pr view {PR_NUMBER} --comments --json comments,reviews
+```
+
+### Step 2 — Parse Reviewer Comments
+
+Locate the three reviewer comments by their emoji headers:
+
+| Emoji | Reviewer |
+|---|---|
+| 🏗️ | Architecture reviewer |
+| 📋 | Spec reviewer |
+| 🧪 | Test reviewer |
+
+From each comment, extract the **Findings** section. Ignore any comments that are not from the automated reviewers.
+
+### Step 3 — Synthesize Findings
+
+Combine the findings from all three reviewers into a unified issue list:
+
+- **Group by severity**: blocking issues first, non-blocking (advisory) issues second.
+- **Deduplicate**: if two reviewers flag the same file/line for the same reason, merge into a single issue.
+- **Number each issue** clearly (e.g., `[1]`, `[2]`, …) so developers can reference them when fixing.
+
+### Step 4 — Decision: Blocking Issues?
+
+#### If blocking issues exist → Post Fix-task comment and add `needs-fix`
+
+```bash
+gh pr comment {PR_NUMBER} -b "## 🔧 Fix Required
+
+The automated review found the following issues that must be resolved before this PR can be approved.
+
+### Blocking Issues
+{numbered list of issues with file references and descriptions}
+
+### Non-Blocking (Advisory)
+{numbered list of advisory issues, or omit section if none}
+
+### How to fix
+1. Address each blocking issue listed above.
+2. Push your changes to this branch.
+3. The review cycle will restart automatically (a new \`review-needed\` label will be applied).
+
+**Review cycle**: {N}/3"
+
+gh pr edit {PR_NUMBER} --add-label "needs-fix"
+```
+
+#### If no blocking issues → Post approval comment and add `approved`
+
+```bash
+gh pr comment {PR_NUMBER} -b "## ✅ Automated Review Approved
+
+All automated review checks have passed:
+- 🏗️ Architecture: ✅ No violations
+- 📋 Spec compliance: ✅ No violations
+- 🧪 Test quality: ✅ No issues
+
+**Next step**: This PR requires a human review (LGTM label) before it can be merged."
+
+gh pr edit {PR_NUMBER} --add-label "approved"
+```
+
+### Step 5 — Re-review Handling (After Developer Fixes)
+
+When the Evaluator is invoked for a PR that already has a previous Fix-task comment:
+
+1. **Retrieve the previous Fix-task issue list** from the PR comment history.
+2. **Get the latest diff** since the last review cycle:
+   ```bash
+   gh pr diff {PR_NUMBER}
+   ```
+3. **For each previously reported issue**, determine whether it is:
+   - ✅ **Resolved** — the relevant code has been changed to address the issue.
+   - ❌ **Still present** — no meaningful change was made to the relevant code.
+4. **Only report issues that are genuinely still unresolved** in the new Fix-task comment. Do not re-report issues that have been fixed.
+5. If all previously reported blocking issues are now resolved, proceed to the approval flow (Step 4, no blocking issues).
+
+## Quick Reference
+
+| Step | Action |
+|---|---|
+| 1 | `gh pr view {PR_NUMBER} --comments --json comments,reviews` |
+| 2 | Find 🏗️ 📋 🧪 comments; extract Findings sections |
+| 3 | Deduplicate and group by severity |
+| 4a | Blocking issues found → Fix-task comment + `needs-fix` label |
+| 4b | No blocking issues → Approval comment + `approved` label |
+| 5 | On re-review: diff against previous Fix-task; only surface unresolved issues |

--- a/.agents/skills/orchestrate-review/SKILL.md
+++ b/.agents/skills/orchestrate-review/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: orchestrate-review
+description: Orchestrates the multi-agent PR review system. Monitors for PRs needing review, spawns reviewer sub-agents, enforces the 3-iteration loop limit, and invokes the Evaluator.
+---
+
+# orchestrate-review
+
+## When to Use
+
+Invoke this skill when you are acting as the **Orchestrator** in the multi-agent PR review system. The Orchestrator is a long-running agent that monitors open PRs and drives the full review pipeline.
+
+## Label State Machine
+
+```
+review-needed → review-in-progress → review-count-1/2/3
+  → needs-fix        (blocking issues found by Evaluator)
+  → approved         (all issues resolved)
+  → LGTM             (added manually by a human maintainer)
+  → manual-review-needed  (loop limit exceeded)
+```
+
+## Monitoring Loop
+
+Poll GitHub continuously for PRs that need processing:
+
+```bash
+while true; do
+  # List open PRs with review-needed label
+  gh pr list --label "review-needed" --json number,title,labels --state open
+
+  # For each PR that does NOT already have the review-in-progress label:
+  #   → Process it (see "Per-PR Processing" below)
+
+  # Wait before the next check (e.g., 2 minutes)
+  sleep 120
+done
+```
+
+**Concurrent PR handling**: Skip any PR that already carries the `review-in-progress` label. This prevents duplicate processing when multiple Orchestrator instances run simultaneously.
+
+## Per-PR Processing
+
+### Step 1 — Check Loop Limit
+
+Before doing anything else, inspect the PR's existing labels:
+
+```bash
+gh pr view {PR_NUMBER} --json labels
+```
+
+| Existing label | Action |
+|---|---|
+| `review-count-3` already present | Post a manual-review comment (see below), add `manual-review-needed`, stop processing this PR |
+| `review-count-2` present | Add `review-count-3`, continue |
+| `review-count-1` present | Add `review-count-2`, continue |
+| None of the above | Add `review-count-1`, continue |
+
+**Manual-review comment** (when loop limit exceeded):
+
+```bash
+gh pr comment {PR_NUMBER} -b "## ⚠️ Manual Review Required
+
+The automated review loop has reached its maximum of 3 iterations without resolving all issues.
+
+A human maintainer must review this PR manually.
+
+**Action required**: Please inspect the Fix-task comments in this thread and review the outstanding issues directly."
+gh pr edit {PR_NUMBER} --add-label "manual-review-needed"
+```
+
+### Step 2 — Mark as In-Progress
+
+```bash
+gh pr edit {PR_NUMBER} --add-label "review-in-progress"
+```
+
+### Step 3 — Get the PR Diff
+
+```bash
+# Get the file list first to understand scope
+gh pr diff {PR_NUMBER} --name-only
+
+# Get the full diff
+gh pr diff {PR_NUMBER}
+```
+
+For very large PRs (> 500 changed lines), summarize the file list to give each sub-agent focused context.
+
+### Step 4 — Spawn 3 Reviewer Sub-Agents
+
+Invoke the three reviewer skills **in parallel** (or sequentially if parallel sub-agents are not supported by the runtime):
+
+| Sub-agent | Skill file |
+|---|---|
+| Architecture reviewer | `.agents/skills/review-architecture/SKILL.md` |
+| Spec reviewer | `.agents/skills/review-spec/SKILL.md` |
+| Test reviewer | `.agents/skills/review-tests/SKILL.md` |
+
+Provide each sub-agent with:
+- The PR number
+- The full diff (or the file list + diff for large PRs)
+- Instruction to post its findings as a `gh pr review` comment before returning
+
+**Fallback (sequential execution)**: If the runtime does not support parallel sub-agents, read each skill file yourself and perform the review role sequentially — Architecture, then Spec, then Tests — posting a `gh pr review` comment after each role before moving on.
+
+### Step 5 — Wait for All Reviews
+
+Confirm that all 3 reviewer comments are present before proceeding:
+
+```bash
+gh pr view {PR_NUMBER} --comments --json comments,reviews
+```
+
+Look for comments with 🏗️, 📋, and 🧪 emoji headers. If any are missing, wait and re-check (up to a reasonable timeout, e.g., 5 minutes).
+
+### Step 6 — Invoke the Evaluator
+
+Read `.agents/skills/evaluate-review/SKILL.md` and perform the Evaluator role for `{PR_NUMBER}`, or spawn it as a sub-agent if supported.
+
+### Step 7 — Clean Up In-Progress Label
+
+After the Evaluator completes:
+
+```bash
+gh pr edit {PR_NUMBER} --remove-label "review-in-progress"
+gh pr edit {PR_NUMBER} --remove-label "review-needed"
+```
+
+## Quick Reference
+
+| Step | Action |
+|---|---|
+| 1 | Check loop limit via `review-count-N` labels; add next counter or halt |
+| 2 | Add `review-in-progress` |
+| 3 | Fetch PR diff (`--name-only` then full) |
+| 4 | Spawn/execute 3 reviewer sub-agents |
+| 5 | Wait for 🏗️ 📋 🧪 comments |
+| 6 | Invoke Evaluator skill |
+| 7 | Remove `review-in-progress` and `review-needed` labels |

--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: review-architecture
+description: Reviews a PR diff for architecture boundary violations in the Parser/Renderer/Executor 3-layer model. Use when performing automated PR review for architecture compliance.
+---
+
+# review-architecture
+
+## When to Use
+
+Invoke this skill when you need to review a pull request for architecture boundary violations in the yali 3-layer model (`CLI Layer → Parser → Renderer → Executor`).
+
+## Step-by-Step Procedure
+
+1. **Read the PR diff**
+   ```bash
+   gh pr diff {PR_NUMBER}
+   ```
+
+2. **Load the layer-guard skill**
+   Read `.agents/skills/layer-guard/SKILL.md` for the full layer checklist and violation criteria.
+
+3. **Apply layer-guard criteria to the diff**
+
+   For each changed file in the diff, identify its layer (by path: `src/parser/`, `src/renderer/`, `src/executor/`, `src/cli/`) and check:
+
+   ### Parser Layer
+   - ✅ Reads YAML files and normalizes them
+   - ✅ Returns `ValidatedCommand`
+   - ❌ Must NOT call the LLM API
+   - ❌ Must NOT expand `{{variable}}` templates
+   - ❌ Must NOT write to stdout or files
+
+   ### Renderer Layer
+   - ✅ Accepts `ValidatedCommand` + variable map as input
+   - ✅ Returns expanded prompt string(s)
+   - ❌ Must NOT perform any file I/O
+   - ❌ Must NOT make network calls
+   - ❌ Must NOT call the LLM API
+   - ❌ Must NOT read environment variables or use randomness
+
+   ### Executor Layer
+   - ✅ The ONLY layer allowed to call the LLM API
+   - ✅ The ONLY layer allowed to perform I/O
+   - ❌ Must NOT parse YAML directly
+   - ❌ Must NOT expand templates directly (must delegate to Renderer)
+
+   ### Cross-Layer Import Check
+   - Imports must flow in one direction: `CLI → Parser → Renderer → Executor`
+   - No reverse imports (e.g., Parser importing from Executor)
+   - No layer-skipping imports
+
+   ### ValidatedCommand Boundary
+   - Raw YAML must not cross the Parser boundary
+   - Renderer and Executor must consume `ValidatedCommand`, not raw YAML
+
+4. **Post the review comment**
+   ```bash
+   gh pr review {PR_NUMBER} --comment -b "🏗️ Architecture Review\n\n{findings}"
+   ```
+
+   Format the `{findings}` using the template below.
+
+## Review Comment Format
+
+```
+🏗️ Architecture Review
+
+## Summary
+{PASS ✅ / ISSUES FOUND ❌}
+
+## Findings
+{list of violations with file:line references, or "No violations found"}
+
+## Recommendation
+{approve / request changes}
+```
+
+## Pass / Fail Criteria
+
+- **PASS ✅**: All changed files comply with their layer's invariants; no cross-layer import violations; `ValidatedCommand` boundary respected.
+- **ISSUES FOUND ❌**: Any forbidden action is present in a layer, cross-layer imports violate the dependency direction, or raw YAML crosses the Parser boundary.
+
+If no violations are found, explicitly state "No violations found" in the Findings section and recommend approval.

--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: review-spec
+description: Reviews a PR diff for compliance with docs/spec-draft.md. Use when performing automated PR review for spec conformance.
+---
+
+# review-spec
+
+## When to Use
+
+Invoke this skill when you need to review a pull request for compliance with the yali specification (`docs/spec-draft.md`).
+
+## Step-by-Step Procedure
+
+1. **Read the PR diff**
+   ```bash
+   gh pr diff {PR_NUMBER}
+   ```
+
+2. **Load the spec-check skill**
+   Read `.agents/skills/spec-check/SKILL.md` for the full spec compliance procedure.
+
+3. **Read the relevant spec sections**
+   Based on which files are changed in the diff, read the corresponding sections of `docs/spec-draft.md`:
+   - Parser changes → YAML schema and normalization sections
+   - Renderer changes → variable interpolation and template sections
+   - Executor changes → LLM API, output format, and error handling sections
+   - CLI changes → CLI flags, arguments, and exit code sections
+
+4. **Apply spec compliance checks to the diff**
+
+   ### ValidatedCommand Type
+   - ✅ Used as the DMZ between Parser and Renderer
+   - ✅ Fields match the spec Appendix definition
+   - ❌ Must not be bypassed or replaced with raw YAML
+
+   ### YAML Schema Normalization
+   - ✅ `model: string` is normalized to `model: { name: string }`
+   - ✅ `prompt: "..."` is promoted to `steps: [{ prompt: "..." }]`
+   - ✅ Validation follows the JSON Schema defined in spec
+
+   ### Variable Interpolation
+   - ✅ Format matches `{{variable}}` (double curly braces)
+   - ✅ Expansion occurs only in the Renderer layer
+   - ❌ No alternative interpolation syntax (e.g., `${variable}`, `{variable}`)
+
+   ### CLI Flags and Behavior
+   - ✅ Flags match those defined in the spec (e.g., `--input`, `--output`)
+   - ✅ stdin detection behavior matches spec
+   - ✅ Command invocation format matches spec: `yali run <file> [flags]`
+
+   ### Error Handling and Exit Codes
+   - ✅ Exit codes match spec definitions (e.g., 0 for success, non-zero for errors)
+   - ✅ Error messages follow spec format
+   - ✅ Validation errors are surfaced at the appropriate layer
+
+5. **Post the review comment**
+   ```bash
+   gh pr review {PR_NUMBER} --comment -b "📋 Spec Compliance Review\n\n{findings}"
+   ```
+
+   Format the `{findings}` using the template below.
+
+## Review Comment Format
+
+```
+📋 Spec Compliance Review
+
+## Summary
+{PASS ✅ / ISSUES FOUND ❌}
+
+## Findings
+{list of spec violations with reference to spec section, or "No violations found"}
+
+## Recommendation
+{approve / request changes}
+```
+
+## Pass / Fail Criteria
+
+- **PASS ✅**: All changed code is consistent with the corresponding spec sections; types, formats, and behaviors match the spec.
+- **ISSUES FOUND ❌**: Any deviation from the spec is found — wrong type structure, incorrect interpolation syntax, mismatched CLI flags, or wrong exit codes.
+
+If no violations are found, explicitly state "No violations found" in the Findings section and recommend approval.

--- a/.agents/skills/review-tests/SKILL.md
+++ b/.agents/skills/review-tests/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: review-tests
+description: Reviews a PR diff for test quality and coverage per architectural layer. Use when performing automated PR review for test adequacy.
+---
+
+# review-tests
+
+## When to Use
+
+Invoke this skill when you need to review a pull request for test quality and coverage across the yali 3-layer architecture.
+
+## Step-by-Step Procedure
+
+1. **Read the PR diff**
+   ```bash
+   gh pr diff {PR_NUMBER}
+   ```
+
+2. **Load the write-test skill**
+   Read `.agents/skills/write-test/SKILL.md` for the full test strategy per architectural layer.
+
+3. **Apply test quality checks to the diff**
+
+   For each new or modified source file, verify that a corresponding test file exists or is updated in the diff.
+
+   ### Renderer Layer Tests
+   - ✅ Must be pure function tests — given the same input, always the same output
+   - ✅ No mocks needed (Renderer has zero side effects)
+   - ✅ Test all `{{variable}}` expansion cases including missing variables and edge cases
+   - ❌ Must NOT mock file I/O or network calls (if mocks are present, Renderer has a side effect violation)
+
+   ### Executor Layer Tests
+   - ✅ Must mock the LLM API (e.g., using `vi.mock` or a stub client)
+   - ✅ Test both success and failure paths (API errors, rate limits, malformed responses)
+   - ✅ Test output formatting for each supported format (text, json, markdown)
+   - ❌ Must NOT make real LLM API calls in tests
+
+   ### Parser Layer Tests
+   - ✅ Test schema normalization (`model: string` → `model: { name: string }`)
+   - ✅ Test shorthand promotion (`prompt: "..."` → `steps: [...]`)
+   - ✅ Test validation errors for invalid YAML input
+   - ✅ Test that `ValidatedCommand` output matches the expected shape
+
+   ### CLI Layer Tests
+   - ✅ Test argument parsing and flag behavior
+   - ✅ Test stdin detection
+   - ✅ Test exit codes for success and error cases
+
+   ### General Test Quality
+   - ✅ Boundary value tests present for edge cases (empty input, null values, max lengths)
+   - ✅ New functions/features have corresponding test files in the diff
+   - ✅ Test descriptions are clear, meaningful, and describe the expected behavior
+   - ✅ Tests follow the Vitest conventions used in this project
+   - ❌ No commented-out tests or skipped test blocks without justification
+
+4. **Post the review comment**
+   ```bash
+   gh pr review {PR_NUMBER} --comment -b "🧪 Test Quality Review\n\n{findings}"
+   ```
+
+   Format the `{findings}` using the template below.
+
+## Review Comment Format
+
+```
+🧪 Test Quality Review
+
+## Summary
+{PASS ✅ / ISSUES FOUND ❌}
+
+## Findings
+{list of test issues or missing coverage, or "No issues found"}
+
+## Recommendation
+{approve / request changes}
+```
+
+## Pass / Fail Criteria
+
+- **PASS ✅**: All new/modified source files have corresponding tests; tests follow per-layer strategy; descriptions are clear; no real LLM API calls in tests.
+- **ISSUES FOUND ❌**: Missing test files for new features, Renderer tests that use mocks, Executor tests that call the real LLM API, or unclear test descriptions.
+
+If no issues are found, explicitly state "No issues found" in the Findings section and recommend approval.

--- a/.github/merge-gate-config.yml
+++ b/.github/merge-gate-config.yml
@@ -1,0 +1,7 @@
+# Merge gate configuration for yali
+# Controls the number of human approvals required before merging
+
+required_lgtm_count: 1  # Number of LGTM labels required (each maintainer adds one)
+
+# AI review label: 'approved' (added automatically by evaluate-review skill)
+# Human review label: 'LGTM' (added manually by human maintainers)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Related Issue
+
+Closes #<!-- issue number -->
+
+## Layer Affected
+
+<!-- Check all that apply -->
+
+- [ ] CLI Layer
+- [ ] Parser
+- [ ] Renderer
+- [ ] Executor
+- [ ] Multiple / Cross-cutting
+
+## Type of Change
+
+<!-- Check one -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code change, no new feature or bug fix
+- [ ] `test` — add or update tests
+- [ ] `docs` — documentation only
+- [ ] `chore` — build process or tooling
+
+## Changes Made
+
+<!-- Brief bullet list of what changed -->
+
+-
+
+## Testing
+
+<!-- What tests were added or updated? How was this verified? -->
+
+-
+
+## Checklist
+
+- [ ] Follows the 3-layer architecture (Parser → Renderer → Executor)
+- [ ] Tests added for new functionality
+- [ ] No cross-layer boundary violations
+- [ ] Follows Conventional Commits format

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,76 @@
+name: Merge Gate
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Checkout (for config file)
+        uses: actions/checkout@v4
+
+      - name: Check required labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Read required LGTM count from config, defaulting to 1
+          CONFIG_FILE=".github/merge-gate-config.yml"
+          if [ -f "$CONFIG_FILE" ]; then
+            REQUIRED_LGTM=$(grep -E '^required_lgtm_count:' "$CONFIG_FILE" | awk '{print $2}' | tr -d '[:space:]') || true
+          fi
+          REQUIRED_LGTM="${REQUIRED_LGTM:-1}"
+          echo "Required LGTM count: $REQUIRED_LGTM"
+
+          # Fetch current PR labels
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          echo "Current labels: $LABELS"
+
+          has_label() {
+            echo "$LABELS" | jq -e --arg l "$1" 'index($l) != null' > /dev/null 2>&1
+          }
+
+          MISSING=()
+          PASS=true
+
+          # Check for 'approved' label (added by AI evaluator)
+          if has_label "approved"; then
+            echo "✅ 'approved' label present (AI review passed)"
+          else
+            echo "❌ 'approved' label missing (AI review not yet complete)"
+            MISSING+=("approved label (AI review)")
+            PASS=false
+          fi
+
+          # Check for sufficient 'LGTM' labels (added manually by maintainers)
+          LGTM_COUNT=$(echo "$LABELS" | jq '[.[] | select(. == "LGTM")] | length')
+          if [ "$LGTM_COUNT" -ge "$REQUIRED_LGTM" ]; then
+            echo "✅ LGTM label present ($LGTM_COUNT/$REQUIRED_LGTM) (human review passed)"
+          else
+            echo "❌ LGTM label missing ($LGTM_COUNT/$REQUIRED_LGTM) (awaiting human review)"
+            MISSING+=("LGTM label (human review, ${LGTM_COUNT}/${REQUIRED_LGTM} present)")
+            PASS=false
+          fi
+
+          if [ "$PASS" = "true" ]; then
+            echo ""
+            echo "🟢 Merge gate passed — PR has all required labels."
+            exit 0
+          else
+            echo ""
+            echo "🔴 Merge gate blocked. Waiting for:"
+            for item in "${MISSING[@]}"; do
+              echo "   • $item"
+            done
+            echo ""
+            echo "Both 'approved' (AI) and 'LGTM' (human maintainer) labels are required to merge."
+            exit 1
+          fi

--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,101 @@
+name: PR Review Trigger
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+jobs:
+  trigger-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Manage labels and trigger review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          # Fetch current labels on the PR
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          echo "Current labels: $LABELS"
+
+          has_label() {
+            echo "$LABELS" | jq -e --arg l "$1" 'index($l) != null' > /dev/null 2>&1
+          }
+
+          # If 'approved' label exists and this is a synchronize event,
+          # remove 'approved' so the new push re-triggers the full review loop.
+          if [ "${{ github.event.action }}" = "synchronize" ] && has_label "approved"; then
+            echo "Removing 'approved' label (new push after approval)"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "approved" || true
+          fi
+
+          # If 'needs-fix' label exists, remove it so the review loop restarts.
+          if has_label "needs-fix"; then
+            echo "Removing 'needs-fix' label (re-review after fix)"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "needs-fix" || true
+          fi
+
+          # Refresh label list after mutations
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name]')
+
+          # Only add 'review-needed' if 'approved' is no longer present
+          if has_label "approved"; then
+            echo "PR already has 'approved' label and no new push detected — skipping review trigger."
+            exit 0
+          fi
+
+          # Ensure 'review-needed' label exists in the repo (create if missing)
+          gh label create "review-needed" --repo "$REPO" --color "0075ca" --description "Queued for multi-agent AI review" 2>/dev/null || true
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "review-needed"
+          echo "Added 'review-needed' label to PR #$PR_NUMBER"
+
+      - name: Post review request comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+
+          if [ "$ACTION" = "synchronize" ]; then
+            TRIGGER_NOTE="🔄 New commits were pushed — restarting the multi-agent review loop."
+          else
+            TRIGGER_NOTE="🆕 PR opened — starting the multi-agent review pipeline."
+          fi
+
+          COMMENT_BODY="## 🤖 Multi-Agent PR Review Triggered
+
+          ${TRIGGER_NOTE}
+
+          **PR:** #${PR_NUMBER} | **Branch:** \`${BRANCH}\`
+
+          The orchestrator will process this PR through the following review pipeline:
+
+          | # | Role                | Skill               |
+          |---|---------------------|---------------------|
+          | 1 | Architecture Review | \`review-architecture\` |
+          | 2 | Spec Review         | \`review-spec\`         |
+          | 3 | Test Review         | \`review-tests\`        |
+
+          ### Instructions for Orchestrator
+
+          1. Read and follow the \`orchestrate-review\` skill.
+          2. Process PR #${PR_NUMBER} through each review agent in sequence.
+          3. After all reviews, invoke the \`evaluate-review\` skill to determine the outcome.
+          4. Apply the appropriate label (\`approved\` or \`needs-fix\`) based on the evaluation.
+
+          > Labels drive the state machine: \`review-needed\` → \`review-in-progress\` → \`review-count-N\` → \`approved\` / \`needs-fix\`
+          > Merge requires both \`approved\` (AI) **and** \`LGTM\` (human maintainer) labels."
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
+          echo "Posted review request comment to PR #$PR_NUMBER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,62 @@ Skills live in `.agents/skills/` and follow the [agentskills.io](https://agentsk
 | `impl-task` | [`.agents/skills/impl-task/SKILL.md`](.agents/skills/impl-task/SKILL.md) | When starting any new implementation task from a GitHub Issue. |
 | `spec-check` | [`.agents/skills/spec-check/SKILL.md`](.agents/skills/spec-check/SKILL.md) | Before opening a PR or when reviewing existing code against the spec. |
 | `write-test` | [`.agents/skills/write-test/SKILL.md`](.agents/skills/write-test/SKILL.md) | When adding or reviewing tests for any layer. |
+| `review-architecture` | [`.agents/skills/review-architecture/SKILL.md`](.agents/skills/review-architecture/SKILL.md) | When acting as Architecture Reviewer for a PR |
+| `review-spec` | [`.agents/skills/review-spec/SKILL.md`](.agents/skills/review-spec/SKILL.md) | When acting as Spec Reviewer for a PR |
+| `review-tests` | [`.agents/skills/review-tests/SKILL.md`](.agents/skills/review-tests/SKILL.md) | When acting as Test Reviewer for a PR |
+| `orchestrate-review` | [`.agents/skills/orchestrate-review/SKILL.md`](.agents/skills/orchestrate-review/SKILL.md) | When acting as Orchestrator to coordinate PR review |
+| `evaluate-review` | [`.agents/skills/evaluate-review/SKILL.md`](.agents/skills/evaluate-review/SKILL.md) | When acting as Evaluator to synthesize reviews and manage fix loop |
+
+---
+
+## PR Review Roles
+
+When a PR is created, the multi-agent review system assigns specific roles. Any agent can take any role using the corresponding skill.
+
+### Role Table
+
+| Role | Trigger | Skill | Responsibility |
+|---|---|---|---|
+| **Orchestrator** | `review-needed` label on PR | `orchestrate-review` | Monitors PRs, spawns reviewer sub-agents, invokes Evaluator, manages the fix loop |
+| **Architecture Reviewer** | Spawned by Orchestrator | `review-architecture` | Reviews PR diff for 3-layer boundary violations |
+| **Spec Reviewer** | Spawned by Orchestrator | `review-spec` | Reviews PR diff for spec-draft.md compliance |
+| **Test Reviewer** | Spawned by Orchestrator | `review-tests` | Reviews PR diff for test quality and coverage |
+| **Evaluator** | Invoked by Orchestrator after all reviews | `evaluate-review` | Synthesizes reviews, creates Fix-task, tracks resolution, adds approved/needs-fix labels |
+
+### Review Flow
+
+```
+PR created/updated
+      ↓
+GitHub Actions → adds review-needed label + posts structured comment
+      ↓
+Orchestrator detects review-needed label (monitoring loop)
+      ↓
+Spawns 3 reviewer sub-agents in parallel:
+  ├── Architecture Reviewer → gh pr review comment
+  ├── Spec Reviewer → gh pr review comment  
+  └── Test Reviewer → gh pr review comment
+      ↓
+Evaluator synthesizes all reviews
+      ↓
+Issues found?
+  YES → adds needs-fix label + posts Fix-task comment → developer fixes → push → loop (max 3x)
+  NO  → adds approved label → awaits human LGTM → merge
+```
+
+### Merge Gate
+
+Both labels are required before merging:
+- `approved` — added automatically by Evaluator when all issues resolved
+- `LGTM` — added manually by a human maintainer
+
+### Becoming the Orchestrator
+
+Any contributor can serve as the Orchestrator for a review cycle:
+
+1. Start your AI agent (Claude Code, Copilot CLI, Cursor, etc.)
+2. Tell it: *"Read `.agents/skills/orchestrate-review/SKILL.md` and start the monitoring loop"*
+3. The agent will poll for `review-needed` labeled PRs and manage the review process
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,3 +97,58 @@ See [`docs/spec-draft.md`](docs/spec-draft.md) for the full specification.
 ## Architecture Decision Records
 
 Significant technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). Please add an ADR when proposing a major change to the tech stack, architecture, or tooling.
+
+---
+
+## AI-Driven PR Review Process
+
+yali uses a multi-agent system to automatically review PRs when they are created or updated.
+
+### How It Works
+
+1. **You create a PR** → GitHub Actions automatically adds the `review-needed` label and posts a structured comment
+2. **An Orchestrator agent** (any contributor running the `orchestrate-review` skill) detects the label and coordinates 3 independent review agents
+3. **Three reviewers** check the PR from different perspectives:
+   - 🏗️ **Architecture**: Checks for 3-layer boundary violations
+   - 📋 **Spec**: Checks for compliance with `docs/spec-draft.md`
+   - 🧪 **Tests**: Checks for test quality and coverage
+4. **An Evaluator agent** synthesizes the reviews and either:
+   - Posts a Fix-task comment with required changes (adds `needs-fix` label)
+   - Marks the PR as approved (adds `approved` label)
+5. **After fixes**, push your changes — the review loop restarts automatically (max 3 iterations)
+6. **A human maintainer** adds the `LGTM` label after their own review
+7. **Merge** becomes available when both `approved` + `LGTM` labels are present
+
+### Participating as the Orchestrator
+
+Any contributor can serve as the Orchestrator for open PRs awaiting review:
+
+1. Ensure you have the `gh` CLI installed and authenticated
+2. Open your preferred AI agent (Claude Code, Copilot CLI, Cursor, etc.)
+3. Tell it: *"Read `.agents/skills/orchestrate-review/SKILL.md` and start the monitoring loop"*
+4. The agent will automatically find PRs with `review-needed` label and manage the full review cycle
+
+> **Note**: The Orchestrator role is intentionally not tied to a specific AI service. Any agent that can read files and run `gh` CLI commands can be the Orchestrator.
+
+### GitHub Actions Cost
+
+**For public repositories (like yali): GitHub Actions is completely free.**
+
+The `pr-review-trigger.yml` and `merge-gate.yml` workflows:
+- Do not call any AI APIs
+- Only run `gh` CLI commands (label management + comments)
+- Run in seconds per trigger
+
+All AI processing happens on contributors' local machines or cloud agents — not in GitHub Actions runners.
+
+### Label Reference
+
+| Label | Added By | Meaning |
+|---|---|---|
+| `review-needed` | GitHub Actions (auto) | PR is awaiting multi-agent review |
+| `review-in-progress` | Orchestrator | Review is currently running (prevents duplicates) |
+| `review-count-1/2/3` | Orchestrator | Current review iteration number |
+| `needs-fix` | Evaluator | Issues found; developer should fix and push |
+| `approved` | Evaluator | All automated review checks passed |
+| `LGTM` | Human maintainer | Human has reviewed and approved |
+| `manual-review-needed` | Orchestrator | Max iterations reached; needs human review |

--- a/docs/adr/0004-multi-agent-pr-review.md
+++ b/docs/adr/0004-multi-agent-pr-review.md
@@ -1,0 +1,157 @@
+# ADR 0004: Multi-Agent PR Review System
+
+- **Date**: 2026-04-12
+- **Status**: Accepted
+
+---
+
+## Context
+
+`yali` is developed primarily by AI agents working on GitHub Issues (see ADR 0002). As the number of PRs grows, two problems emerge:
+
+1. **No consistent review**: PRs submitted by an AI agent are not automatically reviewed — a human maintainer must check each one manually.
+2. **Review quality gaps**: A single reviewer (human or AI) may miss issues in specific dimensions — architecture correctness, spec compliance, and test quality all require different expertise.
+
+The goal is a fully automated PR review system where multiple independent agents review each PR from distinct perspectives, then iterate with the PR author until all issues are resolved.
+
+### Key Constraints
+
+- **Vendor-agnostic**: Must work with Claude Code, GitHub Copilot CLI, OpenAI Codex CLI, Cursor, and any future agent — no hard dependency on a specific AI provider.
+- **No AI API keys in GitHub Secrets**: OSS contributors should not need to configure secrets to participate. All AI processing must happen client-side.
+- **Zero additional cost for public repos**: GitHub Actions for public repositories is free; all AI compute is billed to each contributor's own account.
+- **Self-contained**: The review protocol must be fully describable in files bundled in the repository (`AGENTS.md`, `SKILL.md` files).
+
+---
+
+## Considered Approaches
+
+### A: GitHub Copilot Automatic Code Review
+
+Use GitHub's native Copilot code review feature (enabled in repository settings).
+
+**Rejected**:
+- Vendor lock-in to GitHub Copilot.
+- Single reviewer perspective only (no multi-agent sectioning).
+- Cannot be customized with project-specific rules (3-layer architecture, spec compliance).
+- Not available for all GitHub plan tiers.
+
+### B: Orchestrator-Workers Pattern (local agent only)
+
+An AI agent acts as the Orchestrator, spawning sub-agents for each review perspective, then invoking an Evaluator to synthesize results.
+
+**Partially adopted**: Provides reliability (one entity is responsible for all reviews), but lacks visibility — no trace in the PR of what's happening.
+
+### C: GitHub Actions + Structured PR Comment Protocol
+
+GitHub Actions posts a structured comment to the PR with instructions for independent agents. Any agent can pick up the task and post their review.
+
+**Partially adopted**: Provides transparency (the PR comment is a public audit trail), but has a liveness risk — reviews might not get picked up if no orchestrator is monitoring.
+
+### D: MCP (Model Context Protocol) Integration
+
+Use MCP servers to expose GitHub API as tools for AI agents, enabling richer context access.
+
+**Rejected**:
+- Requires each contributor to configure MCP servers with GitHub PAT or OAuth credentials.
+- Raises the barrier to entry for OSS contributors who already know `gh` CLI.
+- `gh` CLI + Skills bundled in the repository achieve the same goal with zero external dependencies.
+
+### E: External Multi-Agent Platform (LangGraph, CrewAI, AutoGen, etc.)
+
+Use a dedicated multi-agent framework to orchestrate the review pipeline.
+
+**Rejected**:
+- Requires a hosted service or additional infrastructure.
+- Vendor-specific API keys needed in GitHub Secrets.
+- Contradicts the constraint of vendor-agnostic, client-side AI processing.
+
+---
+
+## Decision
+
+Adopt a **Hybrid B+C approach**:
+
+1. **GitHub Actions (trigger layer)**: On PR open/synchronize, automatically:
+   - Adds the `review-needed` label
+   - Posts a structured comment with the review pipeline table and instructions for the Orchestrator
+   - Manages label transitions on re-push (removes `needs-fix`, re-adds `review-needed`)
+
+2. **Orchestrator (local agent, maintainer-run)**: Polls `gh pr list --label "review-needed"` in a monitoring loop. For each unprocessed PR:
+   - Adds `review-in-progress` label (prevents duplicate processing)
+   - Spawns 3 sub-agents in parallel (or sequentially as fallback)
+   - Invokes the Evaluator after all reviews complete
+
+3. **Reviewer sub-agents** (3 parallel agents):
+   - `review-architecture`: checks 3-layer boundary violations
+   - `review-spec`: checks `docs/spec-draft.md` compliance
+   - `review-tests`: checks test quality and coverage
+
+4. **Evaluator**: Synthesizes all review comments, creates a Fix-task, and either adds `needs-fix` or `approved` label.
+
+5. **Merge Gate** (GitHub Actions): Blocks merge unless both `approved` (AI) and `LGTM` (human) labels are present.
+
+### Label State Machine
+
+```
+PR created/updated
+      ↓
+GitHub Actions → review-needed
+      ↓
+Orchestrator → review-in-progress → review-count-1
+      ↓
+3 Reviewers post comments
+      ↓
+Evaluator synthesizes
+      ↓
+Issues found?
+  YES → needs-fix → developer fixes → push → review-needed (loop, max 3×)
+  NO  → approved
+      ↓
+Human adds LGTM
+      ↓
+Merge gate passes → merge
+      ↓ (if 3rd loop also fails)
+manual-review-needed
+```
+
+### Key Sub-Decisions
+
+| Sub-decision | Choice | Reason |
+|---|---|---|
+| **Transport protocol** | `gh` CLI | OSS contributors already know it; zero auth setup beyond `gh auth login` |
+| **AI compute location** | Client-side | No API keys in GitHub Secrets; free for public repos; each contributor uses their own quota |
+| **Loop limit** | 3 iterations | Prevents infinite loops; `review-count-N` labels provide visibility; manual escalation path |
+| **Merge gate** | `approved` + `LGTM` both required | AI catches technical issues; human makes the final judgment call |
+| **Orchestrator deployment** | Maintainer's local agent | Avoids always-on server cost; maintainer controls when review cycles run |
+| **Fallback** | Sequential self-execution | If sub-agents are not supported, the Orchestrator performs all 3 reviewer roles itself |
+
+---
+
+## Consequences
+
+### Positive
+
+- ✅ **Vendor-agnostic**: Any AI agent that can read Markdown and run `gh` CLI commands can participate in any role.
+- ✅ **No secrets**: Zero AI API keys required in GitHub Secrets; all compute is client-side.
+- ✅ **Self-documenting**: The PR comment and label history provide a full audit trail of the review cycle.
+- ✅ **Composable**: Each reviewer skill references existing skills (`layer-guard`, `spec-check`, `write-test`), avoiding duplication.
+- ✅ **Free for OSS**: GitHub Actions workflows only run `gh` CLI commands; no AI API calls in Actions runners.
+- ✅ **Deterministic escalation**: After 3 failed iterations, the system escalates with `manual-review-needed` instead of looping indefinitely.
+
+### Negative / Trade-offs
+
+- ⚠️ **Orchestrator requires a human to start**: The monitoring loop is not always-on — a maintainer must actively run the Orchestrator agent. Reviews are not instantaneous.
+- ⚠️ **Context window limits**: Large PRs may exceed sub-agent context limits. The `orchestrate-review` skill mitigates this with a file-list-first strategy, but very large diffs may still have coverage gaps.
+- ⚠️ **Label proliferation**: The label state machine requires 8+ labels (`review-needed`, `review-in-progress`, `review-count-1/2/3`, `needs-fix`, `approved`, `LGTM`, `manual-review-needed`). Requires upfront label creation in the repository.
+- ⚠️ **Single orchestrator point of failure**: If no one runs the Orchestrator, PRs accumulate `review-needed` labels. Mitigated by: any contributor can start the Orchestrator at any time.
+
+---
+
+## References
+
+- [ADR 0002: Use AGENTS.md and SKILL.md as the Universal AI-Driven Development Foundation](0002-ai-driven-development-foundation.md)
+- [Anthropic: Building Effective Agents — Parallelization Pattern](https://www.anthropic.com/research/building-effective-agents)
+- `.agents/skills/orchestrate-review/SKILL.md` — Orchestrator monitoring loop implementation
+- `.agents/skills/evaluate-review/SKILL.md` — Evaluator fix-loop implementation
+- `.github/workflows/pr-review-trigger.yml` — GitHub Actions trigger layer
+- `.github/workflows/merge-gate.yml` — Merge gate enforcement

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,8 @@ The format follows [MADR (Markdown Architectural Decision Records)](https://adr.
 |---|---|---|---|
 | [0001](0001-language-choice.md) | Language Choice for yali | Accepted | 2026-04-09 |
 | [0002](0002-ai-driven-development-foundation.md) | Use AGENTS.md and SKILL.md as the Universal AI-Driven Development Foundation | Accepted | 2026-04-09 |
+| [0003](0003-npm-distribution-strategy.md) | npm Distribution Strategy for yali | Accepted | 2026-04-10 |
+| [0004](0004-multi-agent-pr-review.md) | Multi-Agent PR Review System | Accepted | 2026-04-12 |
 
 ---
 


### PR DESCRIPTION
## Summary

Implements a fully automated, vendor-agnostic multi-agent PR review system for yali.

When an AI agent creates a PR, multiple independent reviewer agents automatically check it from 3 perspectives, then an Evaluator manages a fix→re-review loop until all issues are resolved.

## How It Works

```
PR created/updated
      ↓
GitHub Actions → adds review-needed label + posts structured comment
      ↓
Orchestrator detects review-needed label (monitoring loop, any contributor)
      ↓
Spawns 3 reviewer sub-agents in parallel:
  ├── 🏗️ Architecture Reviewer → checks 3-layer boundary violations
  ├── 📋 Spec Reviewer → checks spec-draft.md compliance
  └── 🧪 Test Reviewer → checks test quality and coverage
      ↓
Evaluator synthesizes all reviews
      ↓
Issues found?
  YES → adds needs-fix label + Fix-task comment → developer fixes → push → loop (max 3x)
  NO  → adds approved label → awaits human LGTM → merge
```

## Changes

### New Skills (5)
- `.agents/skills/review-architecture/SKILL.md` — architecture boundary violation reviewer
- `.agents/skills/review-spec/SKILL.md` — spec compliance reviewer
- `.agents/skills/review-tests/SKILL.md` — test quality reviewer
- `.agents/skills/orchestrate-review/SKILL.md` — orchestrator with monitoring loop, sub-agent spawning, 3-iteration loop limit
- `.agents/skills/evaluate-review/SKILL.md` — synthesizes reviews, creates Fix-tasks, manages approved/needs-fix labels

### New GitHub Actions Workflows (2)
- `.github/workflows/pr-review-trigger.yml` — adds `review-needed` label + posts structured comment on PR open/synchronize
- `.github/workflows/merge-gate.yml` — blocks merge without both `approved` (AI) + `LGTM` (human) labels

### New Config Files (2)
- `.github/merge-gate-config.yml` — configurable LGTM count (default: 1)
- `.github/pull_request_template.md` — PR description template with layer/type/checklist

### Updated Docs (2)
- `AGENTS.md` — added 5 new skills to table, added PR Review Roles section with role table + review flow diagram
- `CONTRIBUTING.md` — added AI-Driven PR Review Process section (workflow, Orchestrator setup, Actions cost FAQ, label reference)

## Design Decisions

| Decision | Choice | Reason |
|---|---|---|
| **Vendor agnosticism** | gh CLI + Skills/AGENTS.md | OSS contributors use any AI agent; no vendor lock-in |
| **AI API keys** | None needed in GitHub Secrets | All AI runs client-side; Actions only uses gh CLI |
| **Orchestrator** | Maintainer's local agent | Polls `review-needed` label; no always-on server needed |
| **Loop limit** | Max 3 iterations | Prevents infinite loops; `manual-review-needed` label on failure |
| **Merge gate** | `approved` + `LGTM` both required | AI catches technical issues; human makes the final call |

## GitHub Actions Cost

**Free for public repos.** The two new workflows do zero AI API calls — only `gh` CLI label/comment operations. All AI processing is client-side.

---

_This PR was planned and implemented by the GitHub Copilot CLI agent._