### PR TITLE
feat: implement Parser layer with Zod schema normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "js-yaml": "^4.1.0",
-        "openai": "^4.98.0"
+        "openai": "^4.98.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "yali": "dist/cli.js"
@@ -2074,6 +2075,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "openai": "^4.98.0",
-    "js-yaml": "^4.1.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "typescript": "^5.8.3",
-    "vitest": "^3.2.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.0",
-    "@types/js-yaml": "^4.0.9"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.2"
   },
   "engines": {
     "node": ">=20"

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,0 +1,7 @@
+export class ParseError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "ParseError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -93,6 +93,31 @@ describe('ValidatedCommandSchema — extended config (multi-step)', () => {
     });
     expect(result.steps[0].depends_on).toEqual([]);
   });
+
+  it('parses optional name and version fields', () => {
+    const result = ValidatedCommandSchema.parse({
+      name: 'my-cmd',
+      version: '2.0',
+      prompt: 'Hello',
+      model: 'gpt-4o',
+    });
+    expect(result.name).toBe('my-cmd');
+    expect(result.version).toBe('2.0');
+  });
+
+  it('parses tools field correctly', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hello',
+      model: 'gpt-4o',
+      tools: [{ type: 'mcp', server: 'filesystem', allowed_actions: ['read_file'] }],
+    });
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools![0]).toEqual({
+      type: 'mcp',
+      server: 'filesystem',
+      allowed_actions: ['read_file'],
+    });
+  });
 });
 
 describe('ValidatedCommandSchema — validation errors', () => {
@@ -146,6 +171,11 @@ describe('parseCommand — file I/O', () => {
     try { unlinkSync(tmpFile); } catch { /* ignore */ }
   });
 
+  it('throws ParseError when YAML file is empty', () => {
+    writeFileSync(tmpFile, '');
+    expect(() => parseCommand(tmpFile)).toThrowError(ParseError);
+  });
+
   it('parses a minimal YAML file correctly', () => {
     writeFileSync(tmpFile, 'prompt: "Hello {{input}}"\nmodel: gpt-4o\n');
     const result = parseCommand(tmpFile);
@@ -168,6 +198,7 @@ describe('parseCommand — file I/O', () => {
   });
 
   it('ParseError has correct name property', () => {
+    expect.assertions(2);
     try {
       parseCommand('/nonexistent/path/cmd.yaml');
     } catch (e) {

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { parseCommand } from './index.js';
+import { ParseError } from './errors.js';
+import { ValidatedCommandSchema } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Schema-level tests (no file I/O — tests normalization and validation logic)
+// ---------------------------------------------------------------------------
+
+describe('ValidatedCommandSchema — normalization', () => {
+  it('normalizes model string to object form', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hello {{input}}',
+      model: 'gpt-4o',
+    });
+    expect(result.steps[0].model).toEqual({ name: 'gpt-4o' });
+  });
+
+  it('promotes standalone prompt to steps[0]', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Translate: {{input}}',
+      model: 'gpt-4o',
+    });
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].id).toBe('step0');
+    expect(result.steps[0].prompt).toBe('Translate: {{input}}');
+    expect(result.steps[0].depends_on).toEqual([]);
+  });
+
+  it('uses model object form as-is when already an object', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hello',
+      model: { name: 'gpt-4o-mini', temperature: 0.5, max_tokens: 512 },
+    });
+    expect(result.steps[0].model).toEqual({
+      name: 'gpt-4o-mini',
+      temperature: 0.5,
+      max_tokens: 512,
+    });
+  });
+
+  it('defaults input_spec to stdin when input key is absent', () => {
+    const result = ValidatedCommandSchema.parse({ prompt: 'Hi', model: 'gpt-4o' });
+    expect(result.input_spec).toEqual({ from: 'stdin', var: 'input' });
+  });
+
+  it('defaults output_spec to text/stdout when output key is absent', () => {
+    const result = ValidatedCommandSchema.parse({ prompt: 'Hi', model: 'gpt-4o' });
+    expect(result.output_spec).toEqual({ format: 'text', target: 'stdout' });
+  });
+});
+
+describe('ValidatedCommandSchema — standard config', () => {
+  it('parses full standard YAML with explicit input/output', () => {
+    const result = ValidatedCommandSchema.parse({
+      name: 'translate',
+      model: { name: 'gpt-4o', temperature: 0.3 },
+      prompt: 'Translate: {{input}}',
+      input: { from: 'stdin', var: 'input' },
+      output: { format: 'markdown', target: 'stdout' },
+    });
+    expect(result.name).toBe('translate');
+    expect(result.input_spec.from).toBe('stdin');
+    expect(result.output_spec.format).toBe('markdown');
+  });
+});
+
+describe('ValidatedCommandSchema — extended config (multi-step)', () => {
+  it('parses steps array with depends_on', () => {
+    const result = ValidatedCommandSchema.parse({
+      name: 'summarize-and-translate',
+      version: '1.0',
+      steps: [
+        { id: 'summarize', prompt: 'Summarize: {{input}}', model: 'gpt-4o-mini', depends_on: [] },
+        { id: 'translate', prompt: 'Translate: {{steps.summarize.output}}', model: 'gpt-4o', depends_on: ['summarize'] },
+      ],
+      input: { from: 'stdin', var: 'input' },
+      output: { format: 'text', target: 'stdout' },
+    });
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[1].depends_on).toEqual(['summarize']);
+    // model string normalized in each step
+    expect(result.steps[0].model).toEqual({ name: 'gpt-4o-mini' });
+    expect(result.steps[1].model).toEqual({ name: 'gpt-4o' });
+  });
+
+  it('defaults depends_on to [] when not provided in a step', () => {
+    const result = ValidatedCommandSchema.parse({
+      steps: [{ id: 'step1', prompt: 'Do something', model: 'gpt-4o' }],
+    });
+    expect(result.steps[0].depends_on).toEqual([]);
+  });
+});
+
+describe('ValidatedCommandSchema — validation errors', () => {
+  it('throws when neither prompt nor steps is provided', () => {
+    expect(() => ValidatedCommandSchema.parse({ model: 'gpt-4o' })).toThrow();
+  });
+
+  it('throws when input.from is an invalid enum value', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({
+        prompt: 'Hi',
+        model: 'gpt-4o',
+        input: { from: 'http', var: 'input' },
+      }),
+    ).toThrow();
+  });
+
+  it('throws when output.format is an invalid enum value', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({
+        prompt: 'Hi',
+        model: 'gpt-4o',
+        output: { format: 'xml', target: 'stdout' },
+      }),
+    ).toThrow();
+  });
+
+  it('throws when a step is missing required id field', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({
+        steps: [{ prompt: 'No id here', model: 'gpt-4o' }],
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCommand() integration tests (with real temp files)
+// ---------------------------------------------------------------------------
+
+describe('parseCommand — file I/O', () => {
+  let tmpDir: string;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'yali-test-'));
+    tmpFile = join(tmpDir, 'cmd.yaml');
+  });
+
+  afterEach(() => {
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+  });
+
+  it('parses a minimal YAML file correctly', () => {
+    writeFileSync(tmpFile, 'prompt: "Hello {{input}}"\nmodel: gpt-4o\n');
+    const result = parseCommand(tmpFile);
+    expect(result.steps[0].prompt).toBe('Hello {{input}}');
+    expect(result.steps[0].model.name).toBe('gpt-4o');
+  });
+
+  it('throws ParseError when file does not exist', () => {
+    expect(() => parseCommand('/nonexistent/path/cmd.yaml')).toThrowError(ParseError);
+  });
+
+  it('throws ParseError on YAML syntax error', () => {
+    writeFileSync(tmpFile, 'prompt: :\n  - bad: [unclosed\n');
+    expect(() => parseCommand(tmpFile)).toThrowError(ParseError);
+  });
+
+  it('throws ParseError when schema validation fails', () => {
+    writeFileSync(tmpFile, 'model: gpt-4o\n'); // no prompt or steps
+    expect(() => parseCommand(tmpFile)).toThrowError(ParseError);
+  });
+
+  it('ParseError has correct name property', () => {
+    try {
+      parseCommand('/nonexistent/path/cmd.yaml');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ParseError);
+      expect((e as ParseError).name).toBe('ParseError');
+    }
+  });
+});

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs';
+import { load, YAMLException } from 'js-yaml';
+import type { ValidatedCommand } from '../types/index.js';
+import { ValidatedCommandSchema } from './schema.js';
+import { ParseError } from './errors.js';
+
+export function parseCommand(filePath: string): ValidatedCommand {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch (e) {
+    throw new ParseError(`Cannot read file: ${filePath}`, e);
+  }
+
+  let yaml: unknown;
+  try {
+    yaml = load(raw);
+  } catch (e) {
+    if (e instanceof YAMLException) {
+      throw new ParseError(`YAML syntax error in ${filePath}: ${e.message}`, e);
+    }
+    throw new ParseError(`Failed to parse YAML: ${filePath}`, e);
+  }
+
+  const result = ValidatedCommandSchema.safeParse(yaml);
+  if (!result.success) {
+    throw new ParseError(
+      `Invalid command schema in ${filePath}: ${result.error.message}`,
+      result.error,
+    );
+  }
+
+  return result.data;
+}

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import type { ValidatedCommand } from '../types/index.js';
+
+const ModelSpecSchema = z.preprocess(
+  (val) => (typeof val === 'string' ? { name: val } : val),
+  z.object({
+    name: z.string(),
+    temperature: z.number().optional(),
+    max_tokens: z.number().int().optional(),
+  })
+);
+
+const StepSchema = z.object({
+  id: z.string(),
+  prompt: z.string(),
+  model: ModelSpecSchema,
+  depends_on: z.array(z.string()).default([]),
+});
+
+const InputSpecSchema = z.object({
+  from: z.enum(['stdin', 'args', 'file']),
+  var: z.string(),
+  default: z.string().optional(),
+  path: z.string().optional(),
+});
+
+const OutputSpecSchema = z.object({
+  format: z.enum(['text', 'markdown', 'json']),
+  target: z.enum(['stdout', 'file']),
+  path: z.string().optional(),
+});
+
+const ToolSpecSchema = z.object({
+  type: z.string(),
+  server: z.string().optional(),
+  allowed_actions: z.array(z.string()).optional(),
+});
+
+const RawCommandSchema = z.object({
+  name: z.string().optional(),
+  version: z.string().optional(),
+  model: z.union([z.string(), z.object({ name: z.string() }).passthrough()]).optional(),
+  prompt: z.string().optional(),
+  steps: z.array(z.unknown()).optional(),
+  input: z.unknown().optional(),
+  output: z.unknown().optional(),
+  tools: z.array(z.unknown()).optional(),
+});
+
+export const ValidatedCommandSchema: z.ZodType<ValidatedCommand, z.ZodTypeDef, unknown> = z
+  .unknown()
+  .transform((raw, ctx) => {
+    const parsed = RawCommandSchema.safeParse(raw);
+    if (!parsed.success) {
+      parsed.error.issues.forEach((issue) => ctx.addIssue(issue));
+      return z.NEVER;
+    }
+
+    const data = parsed.data;
+
+    // Resolve steps
+    let steps: ValidatedCommand['steps'];
+    if (data.steps !== undefined) {
+      const stepsResult = z.array(StepSchema).safeParse(data.steps);
+      if (!stepsResult.success) {
+        stepsResult.error.issues.forEach((issue) => ctx.addIssue(issue));
+        return z.NEVER;
+      }
+      steps = stepsResult.data;
+    } else if (data.prompt !== undefined) {
+      const modelRaw = data.model ?? 'gpt-4o';
+      const modelResult = ModelSpecSchema.safeParse(modelRaw);
+      if (!modelResult.success) {
+        modelResult.error.issues.forEach((issue) => ctx.addIssue(issue));
+        return z.NEVER;
+      }
+      steps = [{ id: 'step0', prompt: data.prompt, model: modelResult.data, depends_on: [] }];
+    } else {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Must provide either "prompt" or "steps"' });
+      return z.NEVER;
+    }
+
+    // Resolve input_spec
+    let input_spec: ValidatedCommand['input_spec'];
+    if (data.input !== undefined) {
+      const inputResult = InputSpecSchema.safeParse(data.input);
+      if (!inputResult.success) {
+        inputResult.error.issues.forEach((issue) => ctx.addIssue(issue));
+        return z.NEVER;
+      }
+      input_spec = inputResult.data;
+    } else {
+      input_spec = { from: 'stdin', var: 'input' };
+    }
+
+    // Resolve output_spec
+    let output_spec: ValidatedCommand['output_spec'];
+    if (data.output !== undefined) {
+      const outputResult = OutputSpecSchema.safeParse(data.output);
+      if (!outputResult.success) {
+        outputResult.error.issues.forEach((issue) => ctx.addIssue(issue));
+        return z.NEVER;
+      }
+      output_spec = outputResult.data;
+    } else {
+      output_spec = { format: 'text', target: 'stdout' };
+    }
+
+    // Resolve tools
+    let tools: ValidatedCommand['tools'];
+    if (data.tools !== undefined) {
+      const toolsResult = z.array(ToolSpecSchema).safeParse(data.tools);
+      if (!toolsResult.success) {
+        toolsResult.error.issues.forEach((issue) => ctx.addIssue(issue));
+        return z.NEVER;
+      }
+      tools = toolsResult.data;
+    }
+
+    const result: ValidatedCommand = {
+      ...(data.name !== undefined && { name: data.name }),
+      ...(data.version !== undefined && { version: data.version }),
+      steps,
+      input_spec,
+      output_spec,
+      ...(tools !== undefined && { tools }),
+    };
+
+    return result;
+  });


### PR DESCRIPTION
## Summary

Parser層（src/parser/）を実装しました。

## Changes

- **src/parser/schema.ts** — Zodスキーマによる正規化ルール実装
  - model: 'gpt-4o'（string）→ model: { name: 'gpt-4o' }（object）に自動変換
  - prompt: '...'のみ → steps: [{ id: 'step0', ... }] に昇格
  - input/output キー不在時のデフォルト値補完
- **src/parser/errors.ts** — ParseError クラス（fs/yaml/zodの各エラーを統一ラップ）
- **src/parser/index.ts** — parseCommand(filePath: string): ValidatedCommand エントリポイント
- **src/parser/index.test.ts** — Vitestユニットテスト 17件（全Pass）

## Checklist

- [x] layer-guard: アーキテクチャ境界違反なし
- [x] 
pm run build 通過
- [x] 
pm test 全17件通過
- [x] Conventional Commits形式でコミット

Closes #8