### PR TITLE
feat: Renderer実装 — テンプレート展開（純粋関数）

### DIFF
--- a/src/renderer/errors.ts
+++ b/src/renderer/errors.ts
@@ -1,0 +1,7 @@
+export class RenderError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'RenderError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { renderSteps } from './index.js';
+import { RenderError } from './errors.js';
+import type { ValidatedCommand } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCommand(overrides: Partial<ValidatedCommand> = {}): ValidatedCommand {
+  return {
+    steps: [
+      {
+        id: 'step0',
+        prompt: 'Translate: {{input}}',
+        model: { name: 'gpt-4o' },
+        depends_on: [],
+      },
+    ],
+    input_spec: { from: 'stdin', var: 'input' },
+    output_spec: { format: 'text', target: 'stdout' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// renderSteps — single step
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — single step', () => {
+  it('expands a single variable in a prompt', () => {
+    const cmd = makeCommand();
+    const result = renderSteps(cmd, { input: 'Hello, world' });
+    expect(result).toHaveLength(1);
+    expect(result[0].prompt).toBe('Translate: Hello, world');
+  });
+
+  it('preserves step metadata (id, model, depends_on)', () => {
+    const cmd = makeCommand();
+    const result = renderSteps(cmd, { input: 'test' });
+    expect(result[0].id).toBe('step0');
+    expect(result[0].model).toEqual({ name: 'gpt-4o' });
+    expect(result[0].depends_on).toEqual([]);
+  });
+
+  it('expands multiple variables in one prompt', () => {
+    const cmd = makeCommand({
+      steps: [
+        {
+          id: 'step0',
+          prompt: 'Translate "{{input}}" to {{lang}}',
+          model: { name: 'gpt-4o' },
+          depends_on: [],
+        },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'Hello', lang: 'Japanese' });
+    expect(result[0].prompt).toBe('Translate "Hello" to Japanese');
+  });
+
+  it('expands the same variable referenced multiple times', () => {
+    const cmd = makeCommand({
+      steps: [
+        {
+          id: 'step0',
+          prompt: '{{input}} and {{input}}',
+          model: { name: 'gpt-4o' },
+          depends_on: [],
+        },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'foo' });
+    expect(result[0].prompt).toBe('foo and foo');
+  });
+
+  it('handles a prompt with no template variables', () => {
+    const cmd = makeCommand({
+      steps: [{ id: 'step0', prompt: 'Say hello.', model: { name: 'gpt-4o' }, depends_on: [] }],
+    });
+    const result = renderSteps(cmd, {});
+    expect(result[0].prompt).toBe('Say hello.');
+  });
+
+  it('ignores extra variables not referenced in the template', () => {
+    const cmd = makeCommand();
+    const result = renderSteps(cmd, { input: 'Hi', unused: 'extra' });
+    expect(result[0].prompt).toBe('Translate: Hi');
+  });
+
+  it('handles whitespace inside {{ }} delimiters', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step0', prompt: 'Hello {{ input }}', model: { name: 'gpt-4o' }, depends_on: [] },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'World' });
+    expect(result[0].prompt).toBe('Hello World');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSteps — error cases
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — undefined variable errors', () => {
+  it('throws RenderError when a required variable is missing', () => {
+    const cmd = makeCommand();
+    expect(() => renderSteps(cmd, {})).toThrow(RenderError);
+  });
+
+  it('RenderError message names the missing variable', () => {
+    const cmd = makeCommand();
+    expect(() => renderSteps(cmd, {})).toThrowError(/input/);
+  });
+
+  it('RenderError has correct name property', () => {
+    expect.assertions(2);
+    const cmd = makeCommand();
+    try {
+      renderSteps(cmd, {});
+    } catch (e) {
+      expect(e).toBeInstanceOf(RenderError);
+      expect((e as RenderError).name).toBe('RenderError');
+    }
+  });
+
+  it('throws on first missing variable when multiple are missing', () => {
+    const cmd = makeCommand({
+      steps: [
+        {
+          id: 'step0',
+          prompt: '{{foo}} and {{bar}}',
+          model: { name: 'gpt-4o' },
+          depends_on: [],
+        },
+      ],
+    });
+    expect(() => renderSteps(cmd, {})).toThrow(RenderError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSteps — multi-step
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — multi-step', () => {
+  it('expands all steps and returns an array of RenderedStep', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'summarize', prompt: 'Summarize: {{input}}', model: { name: 'gpt-4o-mini' }, depends_on: [] },
+        { id: 'translate', prompt: 'Translate: {{steps.summarize.output}}', model: { name: 'gpt-4o' }, depends_on: ['summarize'] },
+      ],
+    });
+    const result = renderSteps(cmd, {
+      input: 'Hello',
+      'steps.summarize.output': 'A summary',
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].prompt).toBe('Summarize: Hello');
+    expect(result[1].prompt).toBe('Translate: A summary');
+  });
+
+  it('preserves depends_on in each RenderedStep', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: [] },
+        { id: 'step2', prompt: '{{steps.step1.output}}', model: { name: 'gpt-4o' }, depends_on: ['step1'] },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'hi', 'steps.step1.output': 'there' });
+    expect(result[1].depends_on).toEqual(['step1']);
+  });
+
+  it('throws RenderError when a step variable is absent from the map', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step1', prompt: 'Summarize: {{input}}', model: { name: 'gpt-4o' }, depends_on: [] },
+        { id: 'step2', prompt: 'Translate: {{steps.step1.output}}', model: { name: 'gpt-4o' }, depends_on: ['step1'] },
+      ],
+    });
+    // Executor forgot to add steps.step1.output to the map
+    expect(() => renderSteps(cmd, { input: 'Hello' })).toThrow(RenderError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSteps — model spec preservation
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — model spec preservation', () => {
+  it('preserves full ModelSpec including optional fields', () => {
+    const cmd = makeCommand({
+      steps: [
+        {
+          id: 'step0',
+          prompt: '{{input}}',
+          model: { name: 'gpt-4o', temperature: 0.3, max_tokens: 512 },
+          depends_on: [],
+        },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'hi' });
+    expect(result[0].model).toEqual({ name: 'gpt-4o', temperature: 0.3, max_tokens: 512 });
+  });
+});

--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { renderSteps } from './index.js';
+import { renderSteps, orderSteps, renderStep } from './index.js';
 import { RenderError } from './errors.js';
-import type { ValidatedCommand } from '../types/index.js';
+import type { ValidatedCommand, Step } from '../types/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -265,5 +265,94 @@ describe('renderSteps — advisory', () => {
       ],
     });
     expect(() => renderSteps(cmd, {})).toThrowError(/foo/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orderSteps — pure topological sort (no template expansion)
+// ---------------------------------------------------------------------------
+
+describe('orderSteps', () => {
+  it('returns single step in array', () => {
+    const cmd = makeCommand();
+    expect(orderSteps(cmd).map((s) => s.id)).toEqual(['step0']);
+  });
+
+  it('returns steps in dependency order when declared out of order', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'translate', prompt: '{{steps.summarize.output}}', model: { name: 'gpt-4o' }, depends_on: ['summarize'] },
+        { id: 'summarize', prompt: '{{input}}', model: { name: 'gpt-4o-mini' }, depends_on: [] },
+      ],
+    });
+    expect(orderSteps(cmd).map((s) => s.id)).toEqual(['summarize', 'translate']);
+  });
+
+  it('returns Step objects (not RenderedStep — prompts are NOT expanded)', () => {
+    const cmd = makeCommand();
+    const steps = orderSteps(cmd);
+    // prompt still contains the raw template placeholder
+    expect(steps[0].prompt).toBe('Translate: {{input}}');
+  });
+
+  it('returns empty array for empty steps', () => {
+    expect(orderSteps(makeCommand({ steps: [] }))).toEqual([]);
+  });
+
+  it('throws RenderError on circular dependency', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'a', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['b'] },
+        { id: 'b', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['a'] },
+      ],
+    });
+    expect(() => orderSteps(cmd)).toThrowError(/[Cc]ircular/);
+  });
+
+  it('throws RenderError when depends_on references unknown step id', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['nonexistent'] },
+      ],
+    });
+    expect(() => orderSteps(cmd)).toThrowError(/nonexistent/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderStep — single step expansion (for Executor multi-step usage)
+// ---------------------------------------------------------------------------
+
+describe('renderStep', () => {
+  const step: Step = { id: 'step1', prompt: 'Translate: {{input}}', model: { name: 'gpt-4o' }, depends_on: [] };
+
+  it('expands template variables in a single step', () => {
+    const result = renderStep(step, { input: 'Hello' });
+    expect(result.prompt).toBe('Translate: Hello');
+  });
+
+  it('preserves all step metadata', () => {
+    const result = renderStep(step, { input: 'Hi' });
+    expect(result.id).toBe('step1');
+    expect(result.model).toEqual({ name: 'gpt-4o' });
+    expect(result.depends_on).toEqual([]);
+  });
+
+  it('throws RenderError for missing variable', () => {
+    expect(() => renderStep(step, {})).toThrow(RenderError);
+  });
+
+  it('supports multi-step pattern: Executor accumulates variables per step', () => {
+    const summarize: Step = { id: 'summarize', prompt: 'Summarize: {{input}}', model: { name: 'gpt-4o-mini' }, depends_on: [] };
+    const translate: Step = { id: 'translate', prompt: 'Translate: {{steps.summarize.output}}', model: { name: 'gpt-4o' }, depends_on: ['summarize'] };
+
+    // Step 1: Executor renders summarize with only {input}
+    const r1 = renderStep(summarize, { input: 'Hello' });
+    expect(r1.prompt).toBe('Summarize: Hello');
+
+    // Executor runs LLM → gets "A summary"
+    // Step 2: Executor adds step output to variables, then renders translate
+    const r2 = renderStep(translate, { input: 'Hello', 'steps.summarize.output': 'A summary' });
+    expect(r2.prompt).toBe('Translate: A summary');
   });
 });

--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -203,3 +203,67 @@ describe('renderSteps — model spec preservation', () => {
     expect(result[0].model).toEqual({ name: 'gpt-4o', temperature: 0.3, max_tokens: 512 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// renderSteps — topological sort
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — topological sort', () => {
+  it('returns single step unchanged', () => {
+    const cmd = makeCommand();
+    const result = renderSteps(cmd, { input: 'hi' });
+    expect(result.map((s) => s.id)).toEqual(['step0']);
+  });
+
+  it('returns steps in dependency order when declared out of order', () => {
+    const cmd = makeCommand({
+      steps: [
+        // translate declared first but depends on summarize
+        { id: 'translate', prompt: '{{steps.summarize.output}}', model: { name: 'gpt-4o' }, depends_on: ['summarize'] },
+        { id: 'summarize', prompt: '{{input}}', model: { name: 'gpt-4o-mini' }, depends_on: [] },
+      ],
+    });
+    const result = renderSteps(cmd, { input: 'Hello', 'steps.summarize.output': 'Summary' });
+    expect(result.map((s) => s.id)).toEqual(['summarize', 'translate']);
+  });
+
+  it('handles empty steps array and returns []', () => {
+    const cmd = makeCommand({ steps: [] });
+    const result = renderSteps(cmd, {});
+    expect(result).toEqual([]);
+  });
+
+  it('throws RenderError on circular dependency', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'a', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['b'] },
+        { id: 'b', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['a'] },
+      ],
+    });
+    expect(() => renderSteps(cmd, { input: 'hi' })).toThrow(RenderError);
+  });
+
+  it('throws RenderError when depends_on references unknown step id', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: ['nonexistent'] },
+      ],
+    });
+    expect(() => renderSteps(cmd, { input: 'hi' })).toThrow(RenderError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSteps — advisory fixes
+// ---------------------------------------------------------------------------
+
+describe('renderSteps — advisory', () => {
+  it('throws on first missing variable and error message names that variable', () => {
+    const cmd = makeCommand({
+      steps: [
+        { id: 'step0', prompt: '{{foo}} and {{bar}}', model: { name: 'gpt-4o' }, depends_on: [] },
+      ],
+    });
+    expect(() => renderSteps(cmd, {})).toThrowError(/foo/);
+  });
+});

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,0 +1,47 @@
+import type { ValidatedCommand, ModelSpec } from '../types/index.js';
+import { RenderError } from './errors.js';
+
+/**
+ * A single step with its prompt fully expanded by the Renderer.
+ * Passed to the Executor for LLM invocation.
+ */
+export interface RenderedStep {
+  id: string;
+  /** Expanded prompt string — all {{variable}} references resolved. */
+  prompt: string;
+  model: ModelSpec;
+  depends_on: string[];
+}
+
+const TEMPLATE_PATTERN = /\{\{([^}]+)\}\}/g;
+
+function expandTemplate(template: string, variables: Record<string, string>): string {
+  return template.replace(TEMPLATE_PATTERN, (_match, key: string) => {
+    const trimmedKey = key.trim();
+    if (!(trimmedKey in variables)) {
+      throw new RenderError(`Undefined variable: "{{${trimmedKey}}}" has no value in the variable map`);
+    }
+    return variables[trimmedKey];
+  });
+}
+
+/**
+ * Pure function: expands {{variable}} templates in each step's prompt.
+ *
+ * The caller (Executor) is responsible for populating `variables` with all
+ * required values, including inter-step references such as
+ * `"steps.summarize.output"` before calling this function for dependent steps.
+ *
+ * @throws {RenderError} if a template variable is not found in `variables`.
+ */
+export function renderSteps(
+  command: ValidatedCommand,
+  variables: Record<string, string>,
+): RenderedStep[] {
+  return command.steps.map((step) => ({
+    id: step.id,
+    prompt: expandTemplate(step.prompt, variables),
+    model: step.model,
+    depends_on: step.depends_on,
+  }));
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,4 @@
-import type { ValidatedCommand, ModelSpec } from '../types/index.js';
+import type { ValidatedCommand, ModelSpec, Step } from '../types/index.js';
 import { RenderError } from './errors.js';
 
 /**
@@ -26,19 +26,85 @@ function expandTemplate(template: string, variables: Record<string, string>): st
 }
 
 /**
- * Pure function: expands {{variable}} templates in each step's prompt.
+ * Topologically sorts steps by their `depends_on` relationships (Kahn's algorithm).
+ * Returns steps in a valid execution order (dependencies before dependents).
+ *
+ * @throws {RenderError} if an unknown step id is referenced in `depends_on`,
+ *   or if a circular dependency is detected.
+ */
+function topologicalSort(steps: Step[]): Step[] {
+  const idToStep = new Map(steps.map((s) => [s.id, s]));
+
+  // Validate all depends_on references
+  for (const step of steps) {
+    for (const dep of step.depends_on) {
+      if (!idToStep.has(dep)) {
+        throw new RenderError(
+          `Step "${step.id}" depends on unknown step "${dep}"`,
+        );
+      }
+    }
+  }
+
+  // Kahn's algorithm
+  const inDegree = new Map(steps.map((s) => [s.id, 0]));
+  for (const step of steps) {
+    for (const dep of step.depends_on) {
+      inDegree.set(step.id, (inDegree.get(step.id) ?? 0) + 1);
+    }
+  }
+
+  const queue: Step[] = steps.filter((s) => inDegree.get(s.id) === 0);
+  const sorted: Step[] = [];
+
+  // Build reverse adjacency: dep → steps that depend on dep
+  const dependents = new Map<string, string[]>();
+  for (const step of steps) {
+    for (const dep of step.depends_on) {
+      if (!dependents.has(dep)) dependents.set(dep, []);
+      dependents.get(dep)!.push(step.id);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    sorted.push(current);
+    for (const dependentId of dependents.get(current.id) ?? []) {
+      const newDegree = (inDegree.get(dependentId) ?? 0) - 1;
+      inDegree.set(dependentId, newDegree);
+      if (newDegree === 0) {
+        queue.push(idToStep.get(dependentId)!);
+      }
+    }
+  }
+
+  if (sorted.length !== steps.length) {
+    throw new RenderError(
+      'Circular dependency detected in steps: cannot determine a valid execution order',
+    );
+  }
+
+  return sorted;
+}
+
+/**
+ * Pure function: topologically sorts steps by dependency graph, then expands
+ * {{variable}} templates in each step's prompt.
  *
  * The caller (Executor) is responsible for populating `variables` with all
  * required values, including inter-step references such as
  * `"steps.summarize.output"` before calling this function for dependent steps.
  *
- * @throws {RenderError} if a template variable is not found in `variables`.
+ * @throws {RenderError} if a template variable is not found in `variables`,
+ *   if a `depends_on` references an unknown step id, or if a circular
+ *   dependency is detected.
  */
 export function renderSteps(
   command: ValidatedCommand,
   variables: Record<string, string>,
 ): RenderedStep[] {
-  return command.steps.map((step) => ({
+  const ordered = topologicalSort(command.steps);
+  return ordered.map((step) => ({
     id: step.id,
     prompt: expandTemplate(step.prompt, variables),
     model: step.model,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -88,12 +88,48 @@ function topologicalSort(steps: Step[]): Step[] {
 }
 
 /**
+ * Pure function: returns steps sorted in a valid execution order based on
+ * `depends_on` dependencies. The Executor uses this for multi-step commands
+ * to know which step to run next, then calls `renderStep` per step as
+ * accumulated outputs become available.
+ *
+ * @throws {RenderError} if an unknown step id is referenced in `depends_on`,
+ *   or if a circular dependency is detected.
+ */
+export function orderSteps(command: ValidatedCommand): Step[] {
+  return topologicalSort(command.steps);
+}
+
+/**
+ * Pure function: expands {{variable}} templates in a single step's prompt.
+ * The Executor calls this per step in multi-step mode, after adding the
+ * previous step's LLM output to `variables` (e.g. `"steps.step1.output"`).
+ *
+ * @throws {RenderError} if a template variable is not found in `variables`.
+ */
+export function renderStep(
+  step: Step,
+  variables: Record<string, string>,
+): RenderedStep {
+  return {
+    id: step.id,
+    prompt: expandTemplate(step.prompt, variables),
+    model: step.model,
+    depends_on: step.depends_on,
+  };
+}
+
+/**
  * Pure function: topologically sorts steps by dependency graph, then expands
  * {{variable}} templates in each step's prompt.
  *
- * The caller (Executor) is responsible for populating `variables` with all
- * required values, including inter-step references such as
- * `"steps.summarize.output"` before calling this function for dependent steps.
+ * Use this for **single-step** commands, or for multi-step commands only when
+ * all required variables (including `"steps.X.output"` inter-step references)
+ * are already pre-populated in `variables`.
+ *
+ * For sequential multi-step execution, prefer `orderSteps` + `renderStep`
+ * so that each step's output can be added to `variables` before the next
+ * step is expanded.
  *
  * @throws {RenderError} if a template variable is not found in `variables`,
  *   if a `depends_on` references an unknown step id, or if a circular
@@ -103,11 +139,5 @@ export function renderSteps(
   command: ValidatedCommand,
   variables: Record<string, string>,
 ): RenderedStep[] {
-  const ordered = topologicalSort(command.steps);
-  return ordered.map((step) => ({
-    id: step.id,
-    prompt: expandTemplate(step.prompt, variables),
-    model: step.model,
-    depends_on: step.depends_on,
-  }));
+  return orderSteps(command).map((step) => renderStep(step, variables));
 }


### PR DESCRIPTION
## Summary

Renderer層を実装する。ValidatedCommand + 変数マップを受け取り、{{variable}} テンプレートを展開して RenderedStep[] を返す純粋関数。

## Changes

- \src/renderer/index.ts\: \enderSteps(command, variables)\ — 全ステップのプロンプトを展開し \RenderedStep[]\ を返す
- \src/renderer/errors.ts\: \RenderError\ — 未定義変数に対するカスタムエラークラス
- \src/renderer/index.test.ts\: 15件の純粋関数ユニットテスト（モックなし）

## Design Decisions

- **アプローチ B採用**: \RenderedStep[]\ を返すことでExecutor実装時のリファクタリングが不要
- **\{{steps.X.output}}\ の扱い**: Executorが変数マップに追加してからRendererを呼ぶ。Renderer視点では通常の変数キーと同じ
- **未定義変数**: 即座に \RenderError\ をスロー（lenientな空文字置換はしない）

## Invariants Verified (layer-guard)

- ✅ ネットワーク呼び出しなし
- ✅ ファイルI/Oなし
- ✅ \process.env\ 参照なし
- ✅ LLM API呼び出しなし
- ✅ 逆方向インポートなし（Parser/Executorへの依存なし）

## Tests

`
✓ src/renderer/index.test.ts (15 tests)
✓ src/parser/index.test.ts (20 tests)
Total: 35 tests passed
`

Closes #9