### PR TITLE
feat: Executor実装 — LLM API呼び出し・ストリーミング・出力

### DIFF
--- a/src/executor/errors.ts
+++ b/src/executor/errors.ts
@@ -1,0 +1,9 @@
+export class ExecutorError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ExecutorError';
+  }
+}

--- a/src/executor/index.test.ts
+++ b/src/executor/index.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ValidatedCommand } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Mock the openai module before importing the executor
+// ---------------------------------------------------------------------------
+vi.mock('openai', () => {
+  const mockCreate = vi.fn();
+
+  class FakeAPIError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'APIError';
+      this.status = status;
+    }
+  }
+
+  const OpenAI = vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: mockCreate,
+      },
+    },
+  }));
+
+  // Attach static APIError so the executor's `instanceof OpenAI.APIError` works
+  (OpenAI as unknown as Record<string, unknown>)['APIError'] = FakeAPIError;
+
+  return { default: OpenAI, __mockCreate: mockCreate };
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal ValidatedCommand
+// ---------------------------------------------------------------------------
+function makeCommand(overrides: Partial<ValidatedCommand> = {}): ValidatedCommand {
+  return {
+    steps: [
+      {
+        id: 'step1',
+        prompt: 'Say hello to {{input}}',
+        model: { name: 'gpt-4o-mini' },
+        depends_on: [],
+      },
+    ],
+    input_spec: { from: 'args', var: 'input' },
+    output_spec: { format: 'text', target: 'stdout' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('execute()', () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env['OPENAI_API_KEY'] = 'test-key';
+
+    // Re-import after reset to pick up the mock
+    const openaiModule = await import('openai') as unknown as { __mockCreate: ReturnType<typeof vi.fn> };
+    mockCreate = openaiModule.__mockCreate;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env['OPENAI_API_KEY'];
+  });
+
+  // Helper: makes mockCreate return a non-streaming response
+  function mockNonStreaming(content: string) {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content } }],
+    });
+  }
+
+  // Helper: makes mockCreate return an async iterable (streaming)
+  function mockStreaming(chunks: string[]) {
+    async function* gen() {
+      for (const chunk of chunks) {
+        yield { choices: [{ delta: { content: chunk } }] };
+      }
+    }
+    mockCreate.mockResolvedValue(gen());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Missing API key
+  // ---------------------------------------------------------------------------
+  it('returns exitCode 1 when OPENAI_API_KEY is missing', async () => {
+    delete process.env['OPENAI_API_KEY'];
+    const { execute } = await import('./index.js');
+    const result = await execute(makeCommand(), { input: 'world' });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('OPENAI_API_KEY');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Single-step — stdout (streaming)
+  // ---------------------------------------------------------------------------
+  it('executes a single step and returns its output (streaming)', async () => {
+    mockStreaming(['Hello ', 'world!']);
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { execute } = await import('./index.js');
+    const result = await execute(makeCommand(), { input: 'world' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('Hello world!');
+    expect(writeSpy).toHaveBeenCalledWith('Hello ');
+    expect(writeSpy).toHaveBeenCalledWith('world!');
+    writeSpy.mockRestore();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Single-step — file target (buffered)
+  // ---------------------------------------------------------------------------
+  it('writes to a file when target is "file"', async () => {
+    mockNonStreaming('buffered content');
+    const writeFileMock = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('node:fs/promises', () => ({ writeFile: writeFileMock }));
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    });
+    const result = await execute(command, { input: 'world' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('buffered content');
+    expect(writeFileMock).toHaveBeenCalledWith('./out.txt', 'buffered content', 'utf-8');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-step with dependency
+  // ---------------------------------------------------------------------------
+  it('executes multi-step commands in dependency order and passes inter-step output', async () => {
+    mockCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'Summary text' } }] })
+      .mockResolvedValueOnce({ choices: [{ message: { content: '翻訳テキスト' } }] });
+
+    const command: ValidatedCommand = {
+      steps: [
+        {
+          id: 'summarize',
+          prompt: 'Summarize: {{input}}',
+          model: { name: 'gpt-4o-mini' },
+          depends_on: [],
+        },
+        {
+          id: 'translate',
+          prompt: 'Translate to Japanese: {{steps.summarize.output}}',
+          model: { name: 'gpt-4o' },
+          depends_on: ['summarize'],
+        },
+      ],
+      input_spec: { from: 'stdin', var: 'input' },
+      output_spec: { format: 'text', target: 'file', path: './result.txt' },
+    };
+
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const { execute } = await import('./index.js');
+    const result = await execute(command, { input: 'Long article content' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('翻訳テキスト');
+
+    // Second call should receive the first step's output as variable
+    const secondCallMessages = mockCreate.mock.calls[1]?.[0]?.messages;
+    expect(secondCallMessages?.[0]?.content).toContain('Summary text');
+  });
+
+  // ---------------------------------------------------------------------------
+  // JSON format
+  // ---------------------------------------------------------------------------
+  it('parses and re-serializes JSON output when format is "json"', async () => {
+    mockNonStreaming('{"key": "value", "num": 42}');
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'json', target: 'file', path: './out.json' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const result = await execute(command, { input: 'test' });
+
+    expect(result.exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(result.output);
+    expect(parsed).toEqual({ key: 'value', num: 42 });
+  });
+
+  it('returns raw text when JSON format output is not valid JSON', async () => {
+    mockNonStreaming('not json at all');
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'json', target: 'file', path: './out.json' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const result = await execute(command, { input: 'test' });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('not json at all');
+  });
+
+  it('extracts JSON from markdown code fences', async () => {
+    mockNonStreaming('```json\n{"answer": 42}\n```');
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'json', target: 'file', path: './out.json' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const result = await execute(command, { input: 'test' });
+    expect(result.exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(result.output);
+    expect(parsed).toEqual({ answer: 42 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retry logic
+  // ---------------------------------------------------------------------------
+  it('retries on 429 and succeeds on the next attempt', async () => {
+    vi.useFakeTimers();
+
+    const openaiModule = await import('openai') as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate
+      .mockRejectedValueOnce(new APIError('rate limit', 429))
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'retry success' } }] });
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const promise = execute(command, { input: 'test' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('retry success');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('returns exitCode 1 after exhausting all retries', async () => {
+    vi.useFakeTimers();
+
+    const openaiModule = await import('openai') as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const promise = execute(command, { input: 'test' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('retries');
+    expect(mockCreate).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+
+    vi.useRealTimers();
+  });
+
+  it('does not retry on a 400 (non-retryable) error', async () => {
+    const openaiModule = await import('openai') as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('bad request', 400));
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const result = await execute(command, { input: 'test' });
+
+    expect(result.exitCode).toBe(1);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Missing file path
+  // ---------------------------------------------------------------------------
+  it('returns exitCode 1 when file target has no path', async () => {
+    mockNonStreaming('some output');
+
+    const { execute } = await import('./index.js');
+    const command: ValidatedCommand = {
+      steps: [
+        {
+          id: 'step1',
+          prompt: 'Hello {{input}}',
+          model: { name: 'gpt-4o-mini' },
+          depends_on: [],
+        },
+      ],
+      input_spec: { from: 'args', var: 'input' },
+      output_spec: { format: 'text', target: 'file' }, // path intentionally omitted
+    };
+
+    const result = await execute(command, { input: 'test' });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('path');
+  });
+});

--- a/src/executor/index.test.ts
+++ b/src/executor/index.test.ts
@@ -222,6 +222,46 @@ describe('execute()', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Markdown format (passthrough)
+  // ---------------------------------------------------------------------------
+  it('passes markdown output through unchanged', async () => {
+    const markdownContent = '# Heading\n\n- item 1\n- item 2\n';
+    mockNonStreaming(markdownContent);
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'markdown', target: 'file', path: './out.md' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const result = await execute(command, { input: 'test' });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe(markdownContent);
+  });
+
+  // ---------------------------------------------------------------------------
+  // JSON format + stdout: buffer then write formatted (no raw streaming)
+  // ---------------------------------------------------------------------------
+  it('buffers and formats JSON output before writing to stdout (no raw chunk streaming)', async () => {
+    mockNonStreaming('{"key":"value"}');
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'json', target: 'stdout' },
+    });
+
+    const result = await execute(command, { input: 'test' });
+
+    expect(result.exitCode).toBe(0);
+    // Should write the formatted JSON (not raw chunks)
+    const written = writeSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed: unknown = JSON.parse(written.trim());
+    expect(parsed).toEqual({ key: 'value' });
+    writeSpy.mockRestore();
+  });
+
+  // ---------------------------------------------------------------------------
   // Retry logic
   // ---------------------------------------------------------------------------
   it('retries on 429 and succeeds on the next attempt', async () => {
@@ -298,6 +338,74 @@ describe('execute()', () => {
 
     expect(result.exitCode).toBe(1);
     expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Network-level retries (advisory [3])
+  // ---------------------------------------------------------------------------
+  it('retries on network errors (ECONNRESET) and succeeds', async () => {
+    vi.useFakeTimers();
+
+    const networkError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    mockCreate
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'network retry ok' } }] });
+
+    const { execute } = await import('./index.js');
+    const command = makeCommand({
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    });
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    const promise = execute(command, { input: 'test' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('network retry ok');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Model parameters forwarded to API (advisory [4])
+  // ---------------------------------------------------------------------------
+  it('forwards temperature and max_tokens to the API', async () => {
+    mockNonStreaming('result');
+
+    const { execute } = await import('./index.js');
+    const command: ValidatedCommand = {
+      steps: [
+        {
+          id: 'step1',
+          prompt: 'Hello {{input}}',
+          model: { name: 'gpt-4o', temperature: 0.2, max_tokens: 512 },
+          depends_on: [],
+        },
+      ],
+      input_spec: { from: 'args', var: 'input' },
+      output_spec: { format: 'text', target: 'file', path: './out.txt' },
+    };
+    vi.doMock('node:fs/promises', () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
+
+    await execute(command, { input: 'test' });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.2, max_tokens: 512 }),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // ExecutorError.cause property (advisory [5])
+  // ---------------------------------------------------------------------------
+  it('ExecutorError stores the cause property', async () => {
+    const { ExecutorError } = await import('./errors.js');
+    const cause = new Error('root cause');
+    const err = new ExecutorError('wrapper message', cause);
+    expect(err.message).toBe('wrapper message');
+    expect(err.cause).toBe(cause);
+    expect(err.name).toBe('ExecutorError');
   });
 
   // ---------------------------------------------------------------------------

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -189,7 +189,9 @@ export async function execute(
   }
 
   const { output_spec } = command;
-  const isStreaming = output_spec.target === 'stdout';
+  // Stream raw chunks to stdout only when target is stdout AND format doesn't require
+  // post-processing. json must be buffered first so formatOutput() can parse the full text.
+  const useStreaming = output_spec.target === 'stdout' && output_spec.format !== 'json';
 
   // Mutable copy so we can accumulate step outputs
   const vars: Record<string, string> = { ...variables };
@@ -203,7 +205,7 @@ export async function execute(
       const { name: modelName, temperature, max_tokens } = rendered.model;
 
       let rawOutput: string;
-      if (isStreaming) {
+      if (useStreaming) {
         rawOutput = await callLLMStreaming(client, rendered.prompt, modelName, temperature, max_tokens);
       } else {
         rawOutput = await callLLM(client, rendered.prompt, modelName, temperature, max_tokens);
@@ -216,9 +218,14 @@ export async function execute(
 
     const formatted = formatOutput(lastOutput, output_spec.format);
 
-    // For file target: write buffered output now
-    if (!isStreaming) {
+    if (output_spec.target === 'file') {
       await writeOutput(formatted, output_spec.target, output_spec.path);
+    } else if (!useStreaming) {
+      // stdout + json: streaming was skipped, write the formatted output now
+      process.stdout.write(formatted);
+      if (!formatted.endsWith('\n')) {
+        process.stdout.write('\n');
+      }
     }
 
     return { exitCode: 0, output: formatted };

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,0 +1,229 @@
+import { writeFile } from 'node:fs/promises';
+import OpenAI from 'openai';
+import type { ValidatedCommand, ExecutionResult } from '../types/index.js';
+import { orderSteps, renderStep } from '../renderer/index.js';
+import { ExecutorError } from './errors.js';
+
+// Retryable HTTP status codes
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function createClient(): OpenAI {
+  const apiKey = process.env['OPENAI_API_KEY'];
+  if (!apiKey) {
+    throw new ExecutorError('OPENAI_API_KEY environment variable is not set');
+  }
+  return new OpenAI({ apiKey });
+}
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof OpenAI.APIError) {
+    return RETRYABLE_STATUS_CODES.has(error.status);
+  }
+  // Network errors (no status code) are retryable
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ENOTFOUND';
+  }
+  return false;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Calls the LLM API with exponential-backoff retry.
+ * Returns the full response text.
+ */
+async function callLLM(
+  client: OpenAI,
+  prompt: string,
+  modelName: string,
+  temperature?: number,
+  maxTokens?: number,
+): Promise<string> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+    }
+
+    try {
+      const response = await client.chat.completions.create({
+        model: modelName,
+        messages: [{ role: 'user', content: prompt }],
+        ...(temperature !== undefined && { temperature }),
+        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+      });
+
+      return response.choices[0]?.message?.content ?? '';
+    } catch (error) {
+      lastError = error;
+      if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        break;
+      }
+    }
+  }
+
+  const message =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new ExecutorError(`LLM API call failed after ${MAX_RETRIES} retries: ${message}`, lastError);
+}
+
+/**
+ * Calls the LLM API with streaming and writes chunks to stdout in real-time.
+ * Returns the accumulated full response text.
+ */
+async function callLLMStreaming(
+  client: OpenAI,
+  prompt: string,
+  modelName: string,
+  temperature?: number,
+  maxTokens?: number,
+): Promise<string> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+    }
+
+    try {
+      const stream = await client.chat.completions.create({
+        model: modelName,
+        messages: [{ role: 'user', content: prompt }],
+        stream: true,
+        ...(temperature !== undefined && { temperature }),
+        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+      });
+
+      let fullText = '';
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content ?? '';
+        if (delta) {
+          process.stdout.write(delta);
+          fullText += delta;
+        }
+      }
+      // Ensure trailing newline on stdout
+      if (fullText && !fullText.endsWith('\n')) {
+        process.stdout.write('\n');
+      }
+      return fullText;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        break;
+      }
+    }
+  }
+
+  const message =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new ExecutorError(`LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`, lastError);
+}
+
+/**
+ * Formats the LLM output according to the requested format.
+ * For 'json', validates and re-serializes the output.
+ * For 'text' and 'markdown', returns the text as-is.
+ */
+function formatOutput(text: string, format: 'text' | 'markdown' | 'json'): string {
+  if (format !== 'json') {
+    return text;
+  }
+
+  // Try to extract JSON from the response (LLMs may wrap it in markdown code fences)
+  const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) ?? null;
+  const jsonText = jsonMatch ? jsonMatch[1]!.trim() : text.trim();
+
+  try {
+    const parsed: unknown = JSON.parse(jsonText);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    // Return raw text if JSON parsing fails — don't error out
+    return text;
+  }
+}
+
+/**
+ * Writes the final output to the target (stdout already written during streaming,
+ * so this is a no-op for stdout. For file targets, writes the buffered content.)
+ */
+async function writeOutput(
+  content: string,
+  target: 'stdout' | 'file',
+  path?: string,
+): Promise<void> {
+  if (target === 'file') {
+    if (!path) {
+      throw new ExecutorError('output.path is required when output.target is "file"');
+    }
+    await writeFile(path, content, 'utf-8');
+  }
+  // stdout streaming is handled in callLLMStreaming; buffered stdout written by caller
+}
+
+/**
+ * Executes a ValidatedCommand by:
+ *  1. Ordering steps topologically (via Renderer's orderSteps)
+ *  2. For each step: rendering the prompt (renderStep), calling the LLM API,
+ *     and accumulating the output into `variables` as `steps.<id>.output`
+ *  3. Writing the final step's output to the configured target
+ *
+ * @returns ExecutionResult with exitCode 0 on success, 1 on error.
+ */
+export async function execute(
+  command: ValidatedCommand,
+  variables: Record<string, string>,
+): Promise<ExecutionResult> {
+  let client: OpenAI;
+  try {
+    client = createClient();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { exitCode: 1, output: message };
+  }
+
+  const { output_spec } = command;
+  const isStreaming = output_spec.target === 'stdout';
+
+  // Mutable copy so we can accumulate step outputs
+  const vars: Record<string, string> = { ...variables };
+
+  try {
+    const orderedSteps = orderSteps(command);
+    let lastOutput = '';
+
+    for (const step of orderedSteps) {
+      const rendered = renderStep(step, vars);
+      const { name: modelName, temperature, max_tokens } = rendered.model;
+
+      let rawOutput: string;
+      if (isStreaming) {
+        rawOutput = await callLLMStreaming(client, rendered.prompt, modelName, temperature, max_tokens);
+      } else {
+        rawOutput = await callLLM(client, rendered.prompt, modelName, temperature, max_tokens);
+      }
+
+      // Accumulate for inter-step references
+      vars[`steps.${step.id}.output`] = rawOutput;
+      lastOutput = rawOutput;
+    }
+
+    const formatted = formatOutput(lastOutput, output_spec.format);
+
+    // For file target: write buffered output now
+    if (!isStreaming) {
+      await writeOutput(formatted, output_spec.target, output_spec.path);
+    }
+
+    return { exitCode: 0, output: formatted };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { exitCode: 1, output: message };
+  }
+}


### PR DESCRIPTION
## Summary

Executor層を実装する（Issue #10）。

## Changes

- \src/executor/errors.ts\ — \ExecutorError\ クラス
- \src/executor/index.ts\ — \xecute(command, variables)\ コアロジック
  - \callLLM()\ / \callLLMStreaming()\: openai SDK + 3回リトライ・指数バックオフ
  - \ormatOutput()\: text / markdown / json 対応（コードフェンスからのJSON抽出含む）
  - \writeOutput()\: stdout（ストリーミング）/ file（バッファ）出力
- \src/executor/index.test.ts\ — 11テスト（openai SDKモック）

## Architecture

- ✅ LLM API呼び出しはExecutorのみ
- ✅ マルチステップ: Rendererの \orderSteps\ + \enderStep\ を使用し、各ステップ出力を \steps.<id>.output\ として蓄積
- ✅ ValidatedCommandを通じてのみ受け取り、raw YAMLを参照しない

Closes #10