### PR TITLE
feat: implement CLI Layer with argument parsing, stdin detection, and dry-run support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,7 @@ function printUsage(): void {
       'Usage: yali run <command.yaml> [options]',
       '',
       'Options:',
-      '  --input <value>       Set the primary input variable',
-      '  --input-file <path>   Read the primary input from a file',
+      '  --input <value|path>   Set the primary input variable, or file path when input.from is "file"',
       '  --var <key=value>     Set an arbitrary template variable (repeatable)',
       '  --dry-run             Render prompts without calling the LLM',
       '  --format <text|json>  Output format for --dry-run (default: text)',
@@ -27,7 +26,6 @@ export async function main(): Promise<void> {
     args: process.argv.slice(2),
     options: {
       input: { type: 'string' },
-      'input-file': { type: 'string' },
       var: { type: 'string', multiple: true },
       'dry-run': { type: 'boolean', default: false },
       format: { type: 'string', default: 'text' },
@@ -69,7 +67,6 @@ export async function main(): Promise<void> {
     variables = await resolveInput(command, {
       vars,
       inputArg: values['input'],
-      inputFile: values['input-file'],
       hasStdin,
     });
   } catch (e) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,115 @@
+import { parseArgs } from 'node:util';
+import { parseCommand } from './parser/index.js';
+import { orderSteps, renderStep } from './renderer/index.js';
+import { execute } from './executor/index.js';
+import { resolveInput, InputResolverError } from './cli/input-resolver.js';
+import { formatDryRun } from './cli/dry-run-formatter.js';
+
+function printUsage(): void {
+  process.stderr.write(
+    [
+      'Usage: yali run <command.yaml> [options]',
+      '',
+      'Options:',
+      '  --input <value>       Set the primary input variable',
+      '  --input-file <path>   Read the primary input from a file',
+      '  --var <key=value>     Set an arbitrary template variable (repeatable)',
+      '  --dry-run             Render prompts without calling the LLM',
+      '  --format <text|json>  Output format for --dry-run (default: text)',
+      '  --help                Show this help message',
+      '',
+    ].join('\n'),
+  );
+}
+
+export async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      input: { type: 'string' },
+      'input-file': { type: 'string' },
+      var: { type: 'string', multiple: true },
+      'dry-run': { type: 'boolean', default: false },
+      format: { type: 'string', default: 'text' },
+      help: { type: 'boolean', default: false },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+
+  if (values.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  // Expect: yali run <file.yaml>
+  if (positionals[0] !== 'run' || !positionals[1]) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const filePath = positionals[1];
+  const dryRun = values['dry-run'] ?? false;
+  const outputFormat = values['format'] === 'json' ? 'json' : 'text';
+  const vars = values['var'] ?? [];
+
+  // Step 1 — Parse
+  let command;
+  try {
+    command = parseCommand(filePath);
+  } catch (e) {
+    process.stderr.write(`Error: ${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(1);
+  }
+
+  // Step 2 — Resolve input variables
+  const hasStdin = !process.stdin.isTTY;
+  let variables: Record<string, string>;
+  try {
+    variables = await resolveInput(command, {
+      vars,
+      inputArg: values['input'],
+      inputFile: values['input-file'],
+      hasStdin,
+    });
+  } catch (e) {
+    if (e instanceof InputResolverError) {
+      process.stderr.write(`Error: ${e.message}\n`);
+    } else {
+      process.stderr.write(`Error: ${e instanceof Error ? e.message : String(e)}\n`);
+    }
+    process.exit(1);
+  }
+
+  // Step 3a — Dry-run: render only, no LLM call
+  if (dryRun) {
+    try {
+      const orderedSteps = orderSteps(command);
+      const renderedSteps = orderedSteps.map((step) => renderStep(step, variables));
+      const output = formatDryRun(renderedSteps, outputFormat);
+      process.stdout.write(output);
+      if (!output.endsWith('\n')) {
+        process.stdout.write('\n');
+      }
+    } catch (e) {
+      process.stderr.write(`Error: ${e instanceof Error ? e.message : String(e)}\n`);
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
+  // Step 3b — Execute (calls LLM)
+  const result = await execute(command, variables);
+  if (result.exitCode !== 0) {
+    process.stderr.write(`Error: ${result.output}\n`);
+  }
+  process.exit(result.exitCode);
+}
+
+import { fileURLToPath } from 'node:url';
+
+// Only call main() when this file is the direct entry point (not when imported by tests)
+const isEntryPoint = process.argv[1] === fileURLToPath(import.meta.url);
+if (isEntryPoint) {
+  main();
+}

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -146,4 +146,31 @@ describe('CLI Layer', () => {
       expect.objectContaining({ hasStdin: true }),
     );
   });
+
+  it('exits 0 and prints usage when --help is passed', async () => {
+    process.argv = ['node', 'cli.js', '--help'];
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrOutput).toContain('Usage: yali run');
+  });
+
+  it('exits 1 and prints to stderr when parseCommand throws', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'bad.yaml'];
+    mockedParseCommand.mockImplementation(() => { throw new Error('YAML syntax error'); });
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrOutput).toContain('YAML syntax error');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when resolveInput throws InputResolverError', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml'];
+    const { InputResolverError: IRError } = await import('./input-resolver.js');
+    mockedResolveInput.mockRejectedValue(new IRError('bad --var format'));
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrOutput).toContain('bad --var format');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ExecutionResult } from '../types/index.js';
+import type { RenderedStep } from '../renderer/index.js';
+
+// ── Module mocks (hoisted before imports) ─────────────────────────────────
+vi.mock('../parser/index.js', () => ({
+  parseCommand: vi.fn(),
+}));
+vi.mock('../executor/index.js', () => ({
+  execute: vi.fn(),
+}));
+vi.mock('../renderer/index.js', () => ({
+  orderSteps: vi.fn(),
+  renderStep: vi.fn(),
+}));
+vi.mock('./input-resolver.js', () => ({
+  resolveInput: vi.fn(),
+  InputResolverError: class InputResolverError extends Error {},
+}));
+vi.mock('./dry-run-formatter.js', () => ({
+  formatDryRun: vi.fn(),
+}));
+
+import { parseCommand } from '../parser/index.js';
+import { execute } from '../executor/index.js';
+import { orderSteps, renderStep } from '../renderer/index.js';
+import { resolveInput } from './input-resolver.js';
+import { formatDryRun } from './dry-run-formatter.js';
+import { main } from '../cli.js';
+
+const mockedParseCommand = vi.mocked(parseCommand);
+const mockedExecute = vi.mocked(execute);
+const mockedOrderSteps = vi.mocked(orderSteps);
+const mockedRenderStep = vi.mocked(renderStep);
+const mockedResolveInput = vi.mocked(resolveInput);
+const mockedFormatDryRun = vi.mocked(formatDryRun);
+
+const MOCK_COMMAND = {
+  steps: [{ id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: [] }],
+  input_spec: { from: 'args' as const, var: 'input' },
+  output_spec: { format: 'text' as const, target: 'stdout' as const },
+};
+
+const MOCK_RENDERED_STEP: RenderedStep = {
+  id: 'step1',
+  prompt: 'Hello, world',
+  model: { name: 'gpt-4o' },
+  depends_on: [],
+};
+
+describe('CLI Layer', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let exitSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: any) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((() => true) as any);
+
+    // Default happy-path mocks
+    mockedParseCommand.mockReturnValue(MOCK_COMMAND as ReturnType<typeof parseCommand>);
+    mockedResolveInput.mockResolvedValue({ input: 'Hello, world' });
+    mockedExecute.mockResolvedValue({ exitCode: 0, output: 'result' } satisfies ExecutionResult);
+    mockedOrderSteps.mockReturnValue(MOCK_COMMAND.steps);
+    mockedRenderStep.mockReturnValue(MOCK_RENDERED_STEP);
+    mockedFormatDryRun.mockReturnValue('=== Step: step1 ===\nHello, world');
+
+    // Simulate TTY (no piped stdin) by default
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  });
+
+  it('exits 1 and prints usage when subcommand is missing', async () => {
+    process.argv = ['node', 'cli.js'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 and prints usage when yaml file is missing', async () => {
+    process.argv = ['node', 'cli.js', 'run'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 0 on successful execution', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml'];
+    mockedExecute.mockResolvedValue({ exitCode: 0, output: 'ok' });
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedExecute).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('exits 1 and prints to stderr on executor failure', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml'];
+    mockedExecute.mockResolvedValue({ exitCode: 1, output: 'LLM error' });
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrOutput).toContain('LLM error');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('does NOT call execute when --dry-run is passed', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml', '--dry-run'];
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedExecute).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('--dry-run outputs plain text by default', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml', '--dry-run'];
+    mockedFormatDryRun.mockReturnValue('=== Step: step1 ===\nHello');
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedFormatDryRun).toHaveBeenCalledWith(expect.any(Array), 'text');
+  });
+
+  it('--dry-run --format=json outputs JSON', async () => {
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml', '--dry-run', '--format', 'json'];
+    mockedFormatDryRun.mockReturnValue('{"steps":[]}');
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedFormatDryRun).toHaveBeenCalledWith(expect.any(Array), 'json');
+  });
+
+  it('detects piped stdin (hasStdin=true) when isTTY is false', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    process.argv = ['node', 'cli.js', 'run', 'cmd.yaml'];
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedResolveInput).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ hasStdin: true }),
+    );
+  });
+});

--- a/src/cli/dry-run-formatter.test.ts
+++ b/src/cli/dry-run-formatter.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { formatDryRun } from './dry-run-formatter.js';
+import type { RenderedStep } from '../renderer/index.js';
+
+function makeStep(overrides: Partial<RenderedStep> = {}): RenderedStep {
+  return {
+    id: 'step1',
+    prompt: 'Translate the following: Hello',
+    model: { name: 'gpt-4o' },
+    depends_on: [],
+    ...overrides,
+  };
+}
+
+describe('formatDryRun', () => {
+  describe('text format (default)', () => {
+    it('formats a single step with the correct header and prompt', () => {
+      const step = makeStep({ id: 'translate', prompt: 'Translate: Hello' });
+      const output = formatDryRun([step]);
+      expect(output).toContain('=== Step: translate (model: gpt-4o) ===');
+      expect(output).toContain('Translate: Hello');
+    });
+
+    it('separates multiple steps with a double newline', () => {
+      const steps = [
+        makeStep({ id: 'summarize', prompt: 'Summarize this.' }),
+        makeStep({ id: 'translate', prompt: 'Translate this.' }),
+      ];
+      const output = formatDryRun(steps);
+      expect(output).toContain('=== Step: summarize (model: gpt-4o) ===');
+      expect(output).toContain('=== Step: translate (model: gpt-4o) ===');
+      // Double newline between sections
+      expect(output).toMatch(/Summarize this\.\n\n=== Step: translate/);
+    });
+
+    it('includes the model name in the header', () => {
+      const step = makeStep({ model: { name: 'gpt-4o-mini' } });
+      const output = formatDryRun([step]);
+      expect(output).toContain('(model: gpt-4o-mini)');
+    });
+
+    it('returns an empty string for empty steps array', () => {
+      const output = formatDryRun([]);
+      expect(output).toBe('');
+    });
+
+    it('uses text format when format argument is omitted (default)', () => {
+      const step = makeStep();
+      const output = formatDryRun([step]);
+      expect(output).toContain('===');
+      expect(() => JSON.parse(output)).toThrow(); // not JSON
+    });
+  });
+
+  describe('json format', () => {
+    it('returns valid JSON', () => {
+      const step = makeStep();
+      const output = formatDryRun([step], 'json');
+      expect(() => JSON.parse(output)).not.toThrow();
+    });
+
+    it('JSON output contains steps array with expected fields', () => {
+      const step = makeStep({ id: 'step1', prompt: 'Hello', model: { name: 'gpt-4o' }, depends_on: ['dep1'] });
+      const parsed = JSON.parse(formatDryRun([step], 'json'));
+      expect(parsed).toHaveProperty('steps');
+      expect(parsed.steps).toHaveLength(1);
+      expect(parsed.steps[0]).toMatchObject({
+        id: 'step1',
+        prompt: 'Hello',
+        model: { name: 'gpt-4o' },
+        depends_on: ['dep1'],
+      });
+    });
+
+    it('JSON output is pretty-printed (2-space indent)', () => {
+      const step = makeStep();
+      const output = formatDryRun([step], 'json');
+      // Pretty-printed JSON will have newlines and indentation
+      expect(output).toContain('\n');
+      expect(output).toContain('  ');
+    });
+
+    it('handles multiple steps in JSON output', () => {
+      const steps = [
+        makeStep({ id: 'step1', prompt: 'First' }),
+        makeStep({ id: 'step2', prompt: 'Second' }),
+      ];
+      const parsed = JSON.parse(formatDryRun(steps, 'json'));
+      expect(parsed.steps).toHaveLength(2);
+      expect(parsed.steps[0].id).toBe('step1');
+      expect(parsed.steps[1].id).toBe('step2');
+    });
+
+    it('returns empty steps array for empty input in JSON format', () => {
+      const parsed = JSON.parse(formatDryRun([], 'json'));
+      expect(parsed).toEqual({ steps: [] });
+    });
+  });
+});

--- a/src/cli/dry-run-formatter.ts
+++ b/src/cli/dry-run-formatter.ts
@@ -1,0 +1,33 @@
+import type { RenderedStep } from '../renderer/index.js';
+
+/**
+ * Formats the output of a --dry-run invocation.
+ * Default is plain text for human readability; pass format='json' for machine-readable output.
+ */
+export function formatDryRun(
+  steps: RenderedStep[],
+  format: 'text' | 'json' = 'text',
+): string {
+  if (format === 'json') {
+    return JSON.stringify(
+      {
+        steps: steps.map((s) => ({
+          id: s.id,
+          prompt: s.prompt,
+          model: s.model,
+          depends_on: s.depends_on,
+        })),
+      },
+      null,
+      2,
+    );
+  }
+
+  // Plain text — human-readable
+  return steps
+    .map((s) => {
+      const header = `=== Step: ${s.id} (model: ${s.model.name}) ===`;
+      return `${header}\n${s.prompt}`;
+    })
+    .join('\n\n');
+}

--- a/src/cli/input-resolver.test.ts
+++ b/src/cli/input-resolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'node:stream';
+import { resolveInput, InputResolverError } from './input-resolver.js';
+import type { ValidatedCommand } from '../types/index.js';
+
+// Minimal ValidatedCommand fixture
+function makeCommand(overrides: Partial<ValidatedCommand['input_spec']> = {}): ValidatedCommand {
+  return {
+    steps: [
+      { id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: [] },
+    ],
+    input_spec: {
+      from: 'args',
+      var: 'input',
+      ...overrides,
+    },
+    output_spec: { format: 'text', target: 'stdout' },
+  };
+}
+
+function makeReadable(text: string): NodeJS.ReadableStream {
+  return Readable.from([text]);
+}
+
+describe('resolveInput — Input Resolution Order', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Priority 4: uses YAML default when nothing else is provided', async () => {
+    const command = makeCommand({ from: 'args', default: 'default-value' });
+    const result = await resolveInput(command, { vars: [], hasStdin: false });
+    expect(result).toEqual({ input: 'default-value' });
+  });
+
+  it('Priority 2: stdin overrides YAML default', async () => {
+    const command = makeCommand({ from: 'stdin', default: 'default-value' });
+    const result = await resolveInput(command, {
+      vars: [],
+      hasStdin: true,
+      stdin: makeReadable('from-stdin'),
+    });
+    expect(result).toEqual({ input: 'from-stdin' });
+  });
+
+  it('Priority 2: --input arg overrides stdin', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputArg: 'from-arg',
+      hasStdin: true,
+      stdin: makeReadable('from-stdin'),
+    });
+    // --input (inputArg) is applied after stdin, so it wins
+    expect(result['input']).toBe('from-arg');
+  });
+
+  it('Priority 1: --var overrides --input arg', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: ['input=from-var'],
+      inputArg: 'from-arg',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('from-var');
+  });
+
+  it('Priority 1: multiple --var flags set independent variables', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: ['topic=AI', 'lang=Japanese'],
+      hasStdin: false,
+    });
+    expect(result['topic']).toBe('AI');
+    expect(result['lang']).toBe('Japanese');
+  });
+
+  it('Priority 1: --var with key=value=more preserves the rest of value', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: ['url=https://example.com/path?q=1'],
+      hasStdin: false,
+    });
+    expect(result['url']).toBe('https://example.com/path?q=1');
+  });
+
+  it('Priority 3: reads file when input.from is file and inputFile is provided', async () => {
+    vi.mock('node:fs', () => ({
+      readFileSync: vi.fn().mockReturnValue('file-content'),
+    }));
+    // Re-import to pick up mock — use inline mock instead
+    const fsMod = await import('node:fs');
+    vi.spyOn(fsMod, 'readFileSync').mockReturnValue('file-content' as unknown as ReturnType<typeof fsMod.readFileSync>);
+
+    const command = makeCommand({ from: 'file' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputFile: './data.txt',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('file-content');
+  });
+
+  it('throws InputResolverError when --var format is invalid', async () => {
+    const command = makeCommand({ from: 'args' });
+    await expect(
+      resolveInput(command, { vars: ['no-equals-sign'], hasStdin: false }),
+    ).rejects.toThrow(InputResolverError);
+  });
+
+  it('throws InputResolverError when input file cannot be read', async () => {
+    const fsMod = await import('node:fs');
+    vi.spyOn(fsMod, 'readFileSync').mockImplementation(() => {
+      throw new Error('ENOENT: file not found');
+    });
+
+    const command = makeCommand({ from: 'file', path: './missing.txt' });
+    await expect(
+      resolveInput(command, { vars: [], hasStdin: false }),
+    ).rejects.toThrow(InputResolverError);
+  });
+
+  it('returns empty object when no sources apply', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, { vars: [], hasStdin: false });
+    expect(result).toEqual({});
+  });
+});

--- a/src/cli/input-resolver.test.ts
+++ b/src/cli/input-resolver.test.ts
@@ -3,6 +3,14 @@ import { Readable } from 'node:stream';
 import { resolveInput, InputResolverError } from './input-resolver.js';
 import type { ValidatedCommand } from '../types/index.js';
 
+// Hoist node:fs mock so vi.mocked(readFileSync) works in ESM
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+import { readFileSync } from 'node:fs';
+const mockedReadFileSync = vi.mocked(readFileSync);
+
 // Minimal ValidatedCommand fixture
 function makeCommand(overrides: Partial<ValidatedCommand['input_spec']> = {}): ValidatedCommand {
   return {
@@ -24,43 +32,115 @@ function makeReadable(text: string): NodeJS.ReadableStream {
 
 describe('resolveInput — Input Resolution Order', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.resetAllMocks();
   });
 
-  it('Priority 4: uses YAML default when nothing else is provided', async () => {
+  // ── Priority 4: YAML default ───────────────────────────────────────────
+
+  it('Priority 4: uses YAML default when nothing else is provided (args source)', async () => {
     const command = makeCommand({ from: 'args', default: 'default-value' });
     const result = await resolveInput(command, { vars: [], hasStdin: false });
     expect(result).toEqual({ input: 'default-value' });
   });
 
-  it('Priority 2: stdin overrides YAML default', async () => {
+  it('Priority 4: uses YAML default when stdin is not piped (stdin source)', async () => {
+    const command = makeCommand({ from: 'stdin', default: 'default-value' });
+    const result = await resolveInput(command, { vars: [], hasStdin: false });
+    expect(result).toEqual({ input: 'default-value' });
+  });
+
+  // ── Primary source gated by input.from ────────────────────────────────
+
+  it('from=stdin: reads piped stdin and maps to input var', async () => {
+    const command = makeCommand({ from: 'stdin' });
+    const result = await resolveInput(command, {
+      vars: [],
+      hasStdin: true,
+      stdin: makeReadable('hello from stdin'),
+    });
+    expect(result).toEqual({ input: 'hello from stdin' });
+  });
+
+  it('from=stdin: stdin overrides YAML default', async () => {
     const command = makeCommand({ from: 'stdin', default: 'default-value' });
     const result = await resolveInput(command, {
       vars: [],
       hasStdin: true,
       stdin: makeReadable('from-stdin'),
     });
-    expect(result).toEqual({ input: 'from-stdin' });
+    expect(result['input']).toBe('from-stdin');
   });
 
-  it('Priority 2: --input arg overrides stdin', async () => {
+  it('from=stdin: --input arg is ignored (stdin source uses piped stdin)', async () => {
+    const command = makeCommand({ from: 'stdin' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputArg: 'should-be-ignored',
+      hasStdin: true,
+      stdin: makeReadable('from-stdin'),
+    });
+    expect(result['input']).toBe('from-stdin');
+  });
+
+  it('from=args: --input value is used directly', async () => {
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputArg: 'hello',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('hello');
+  });
+
+  it('from=args: stdin is not consumed even when piped', async () => {
     const command = makeCommand({ from: 'args' });
     const result = await resolveInput(command, {
       vars: [],
       inputArg: 'from-arg',
       hasStdin: true,
-      stdin: makeReadable('from-stdin'),
+      stdin: makeReadable('should-be-ignored'),
     });
-    // --input (inputArg) is applied after stdin, so it wins
     expect(result['input']).toBe('from-arg');
   });
 
-  it('Priority 1: --var overrides --input arg', async () => {
+  it('from=file: reads file at path given by --input', async () => {
+    mockedReadFileSync.mockReturnValue('file-content' as unknown as ReturnType<typeof readFileSync>);
+    const command = makeCommand({ from: 'file' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputArg: './data.txt',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('file-content');
+    expect(mockedReadFileSync).toHaveBeenCalledWith('./data.txt', 'utf-8');
+  });
+
+  it('from=file: falls back to input.path from YAML when --input is not provided', async () => {
+    mockedReadFileSync.mockReturnValue('yaml-path-content' as unknown as ReturnType<typeof readFileSync>);
+    const command = makeCommand({ from: 'file', path: './default.txt' });
+    const result = await resolveInput(command, { vars: [], hasStdin: false });
+    expect(result['input']).toBe('yaml-path-content');
+    expect(mockedReadFileSync).toHaveBeenCalledWith('./default.txt', 'utf-8');
+  });
+
+  // ── Priority 1: --var (highest priority) ──────────────────────────────
+
+  it('Priority 1: --var overrides --input arg (args source)', async () => {
     const command = makeCommand({ from: 'args' });
     const result = await resolveInput(command, {
       vars: ['input=from-var'],
       inputArg: 'from-arg',
       hasStdin: false,
+    });
+    expect(result['input']).toBe('from-var');
+  });
+
+  it('Priority 1: --var overrides stdin (stdin source)', async () => {
+    const command = makeCommand({ from: 'stdin' });
+    const result = await resolveInput(command, {
+      vars: ['input=from-var'],
+      hasStdin: true,
+      stdin: makeReadable('from-stdin'),
     });
     expect(result['input']).toBe('from-var');
   });
@@ -75,7 +155,7 @@ describe('resolveInput — Input Resolution Order', () => {
     expect(result['lang']).toBe('Japanese');
   });
 
-  it('Priority 1: --var with key=value=more preserves the rest of value', async () => {
+  it('Priority 1: --var with key=value=more preserves the rest of the value', async () => {
     const command = makeCommand({ from: 'args' });
     const result = await resolveInput(command, {
       vars: ['url=https://example.com/path?q=1'],
@@ -84,24 +164,9 @@ describe('resolveInput — Input Resolution Order', () => {
     expect(result['url']).toBe('https://example.com/path?q=1');
   });
 
-  it('Priority 3: reads file when input.from is file and inputFile is provided', async () => {
-    vi.mock('node:fs', () => ({
-      readFileSync: vi.fn().mockReturnValue('file-content'),
-    }));
-    // Re-import to pick up mock — use inline mock instead
-    const fsMod = await import('node:fs');
-    vi.spyOn(fsMod, 'readFileSync').mockReturnValue('file-content' as unknown as ReturnType<typeof fsMod.readFileSync>);
+  // ── Error cases ───────────────────────────────────────────────────────
 
-    const command = makeCommand({ from: 'file' });
-    const result = await resolveInput(command, {
-      vars: [],
-      inputFile: './data.txt',
-      hasStdin: false,
-    });
-    expect(result['input']).toBe('file-content');
-  });
-
-  it('throws InputResolverError when --var format is invalid', async () => {
+  it('throws InputResolverError when --var format is invalid (no =)', async () => {
     const command = makeCommand({ from: 'args' });
     await expect(
       resolveInput(command, { vars: ['no-equals-sign'], hasStdin: false }),
@@ -109,11 +174,9 @@ describe('resolveInput — Input Resolution Order', () => {
   });
 
   it('throws InputResolverError when input file cannot be read', async () => {
-    const fsMod = await import('node:fs');
-    vi.spyOn(fsMod, 'readFileSync').mockImplementation(() => {
+    mockedReadFileSync.mockImplementation(() => {
       throw new Error('ENOENT: file not found');
     });
-
     const command = makeCommand({ from: 'file', path: './missing.txt' });
     await expect(
       resolveInput(command, { vars: [], hasStdin: false }),

--- a/src/cli/input-resolver.ts
+++ b/src/cli/input-resolver.ts
@@ -27,9 +27,11 @@ export function readStream(stream: NodeJS.ReadableStream): Promise<string> {
  * Resolves the variable map for a command according to the Input Resolution Order
  * defined in spec §2 (highest priority first):
  *
- *   1. CLI --var key=value flags
- *   2. stdin (piped text)  → mapped to `input_spec.var`
- *   3. File  (input.from: file, --input-file <path> or input.path)
+ *   1. CLI --var key=value flags  (always highest — any variable)
+ *   2/3. Primary input source — determined by input_spec.from:
+ *        - 'args'  → --input <value>
+ *        - 'stdin' → piped stdin text
+ *        - 'file'  → --input <path> (or input.path from YAML) read as file
  *   4. Default value defined in YAML (input.default)
  *
  * Returns a Record<string, string> ready to pass to the Renderer.
@@ -39,10 +41,13 @@ export async function resolveInput(
   opts: {
     /** Values from --var key=value (may be supplied multiple times). */
     vars: string[];
-    /** Value from --input flag (maps to input_spec.var, treated as args source). */
+    /**
+     * Value from --input flag.
+     * - When input.from === 'args': used directly as the variable value.
+     * - When input.from === 'file': treated as the file path to read.
+     * - When input.from === 'stdin': ignored (stdin is used instead).
+     */
     inputArg?: string;
-    /** Path from --input-file flag (used when input.from === 'file'). */
-    inputFile?: string;
     /** Whether stdin is available (i.e. !process.stdin.isTTY). */
     hasStdin: boolean;
     /** Injectable stdin stream for testing. Defaults to process.stdin. */
@@ -57,9 +62,10 @@ export async function resolveInput(
     variables[input_spec.var] = input_spec.default;
   }
 
-  // Priority 3 — File source
+  // Priority 2/3 — Primary input source, gated by input.from (spec §2)
   if (input_spec.from === 'file') {
-    const filePath = opts.inputFile ?? input_spec.path;
+    // --input provides the file path; fall back to input.path from YAML
+    const filePath = opts.inputArg ?? input_spec.path;
     if (filePath) {
       try {
         variables[input_spec.var] = readFileSync(filePath, 'utf-8');
@@ -69,18 +75,15 @@ export async function resolveInput(
         );
       }
     }
-  }
-
-  // Priority 2 — stdin (piped)
-  if (opts.hasStdin) {
-    const stream = opts.stdin ?? process.stdin;
-    const text = await readStream(stream);
-    variables[input_spec.var] = text;
-  }
-
-  // Priority 2 (args source) — --input flag maps to the primary input variable
-  if (opts.inputArg !== undefined) {
-    variables[input_spec.var] = opts.inputArg;
+  } else if (input_spec.from === 'stdin') {
+    if (opts.hasStdin) {
+      const stream = opts.stdin ?? process.stdin;
+      variables[input_spec.var] = await readStream(stream);
+    }
+  } else if (input_spec.from === 'args') {
+    if (opts.inputArg !== undefined) {
+      variables[input_spec.var] = opts.inputArg;
+    }
   }
 
   // Priority 1 — --var key=value flags (highest priority, applied last)

--- a/src/cli/input-resolver.ts
+++ b/src/cli/input-resolver.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import type { ValidatedCommand } from '../types/index.js';
+
+export class InputResolverError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InputResolverError';
+  }
+}
+
+/**
+ * Reads all available bytes from a Readable stream and resolves with the result.
+ * Used to consume stdin when it is piped (not a TTY).
+ */
+export function readStream(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (chunk: Buffer | string) =>
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+    );
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    stream.on('error', reject);
+  });
+}
+
+/**
+ * Resolves the variable map for a command according to the Input Resolution Order
+ * defined in spec §2 (highest priority first):
+ *
+ *   1. CLI --var key=value flags
+ *   2. stdin (piped text)  → mapped to `input_spec.var`
+ *   3. File  (input.from: file, --input-file <path> or input.path)
+ *   4. Default value defined in YAML (input.default)
+ *
+ * Returns a Record<string, string> ready to pass to the Renderer.
+ */
+export async function resolveInput(
+  command: ValidatedCommand,
+  opts: {
+    /** Values from --var key=value (may be supplied multiple times). */
+    vars: string[];
+    /** Value from --input flag (maps to input_spec.var, treated as args source). */
+    inputArg?: string;
+    /** Path from --input-file flag (used when input.from === 'file'). */
+    inputFile?: string;
+    /** Whether stdin is available (i.e. !process.stdin.isTTY). */
+    hasStdin: boolean;
+    /** Injectable stdin stream for testing. Defaults to process.stdin. */
+    stdin?: NodeJS.ReadableStream;
+  },
+): Promise<Record<string, string>> {
+  const variables: Record<string, string> = {};
+  const { input_spec } = command;
+
+  // Priority 4 — YAML default (lowest priority, applied first so higher ones can override)
+  if (input_spec.default !== undefined) {
+    variables[input_spec.var] = input_spec.default;
+  }
+
+  // Priority 3 — File source
+  if (input_spec.from === 'file') {
+    const filePath = opts.inputFile ?? input_spec.path;
+    if (filePath) {
+      try {
+        variables[input_spec.var] = readFileSync(filePath, 'utf-8');
+      } catch (e) {
+        throw new InputResolverError(
+          `Cannot read input file: ${filePath} — ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+  }
+
+  // Priority 2 — stdin (piped)
+  if (opts.hasStdin) {
+    const stream = opts.stdin ?? process.stdin;
+    const text = await readStream(stream);
+    variables[input_spec.var] = text;
+  }
+
+  // Priority 2 (args source) — --input flag maps to the primary input variable
+  if (opts.inputArg !== undefined) {
+    variables[input_spec.var] = opts.inputArg;
+  }
+
+  // Priority 1 — --var key=value flags (highest priority, applied last)
+  for (const pair of opts.vars) {
+    const eqIdx = pair.indexOf('=');
+    if (eqIdx === -1) {
+      throw new InputResolverError(
+        `Invalid --var format: "${pair}". Expected "key=value".`,
+      );
+    }
+    const key = pair.slice(0, eqIdx);
+    const value = pair.slice(eqIdx + 1);
+    variables[key] = value;
+  }
+
+  return variables;
+}


### PR DESCRIPTION
## Summary

Implements the CLI Layer (src/cli.ts) — the final layer in yali's 3-layer architecture. After this PR, \yali run\ is fully operational end-to-end.

## Changes

- \src/cli.ts\ — Entry point. Uses \
ode:util\ \parseArgs\ to handle \--input\, \--input-file\, \--var\, \--dry-run\, \--format\, \--help\. Orchestrates Parser → Renderer → Executor. Guards \main()\ with \import.meta.url\ so tests can import without side effects.
- \src/cli/input-resolver.ts\ — Implements Input Resolution Order (spec §2): CLI \--var\ > stdin > file > YAML default. Injectable stdin stream for testability.
- \src/cli/dry-run-formatter.ts\ — Pure formatter for \--dry-run\ output. Plain text by default; \--format=json\ for machine-readable output (CI/script integration).
- \src/cli/input-resolver.test.ts\ — 10 unit tests covering all priority levels.
- \src/cli/cli.test.ts\ — 8 integration tests with mocked \xecute\/\parseCommand\; verifies \--dry-run\ never calls LLM.

## Architecture Compliance

- ✅ CLI Layer calls Parser → Renderer → Executor in correct direction
- ✅ No direct YAML parsing, LLM API calls, or template expansion in CLI Layer
- ✅ \--dry-run\ calls Renderer only, never Executor
- ✅ \import.meta.url\ guard prevents accidental \main()\ execution on import

Closes #11