### PR TITLE
docs: add comprehensive user guide in English and Japanese

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,110 @@
+# yali — YAML LLM Interface
+
+[![CI](https://github.com/your-org/yali/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/yali/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node.js 20+](https://img.shields.io/badge/Node.js-20%2B-green.svg)](https://nodejs.org/)
+
+> YAMLでLLMコマンドを定義して、ターミナルから一発で実行できるオープンソースCLIツール。
+
+---
+
+## 特徴
+
+- **シンプルなYAML定義** — `prompt` と `model` の2行から始められる最小構成
+- **マルチステップパイプライン** — `steps[]` と `depends_on` で複数のLLM呼び出しを連鎖
+- **柔軟な入力ソース** — `stdin`・コマンドライン引数・ファイルに対応
+- **出力フォーマット制御** — `text` / `markdown` / `json` を選択、`stdout` またはファイルへ出力
+- **ドライランモード** — `--dry-run` でLLMを呼び出さずにプロンプトを確認
+- **テンプレート変数** — `{{variable}}` 構文で任意の変数を埋め込み
+
+---
+
+## クイックスタート
+
+### 前提条件
+
+- Node.js 20 以上
+- OpenAI API キー（環境変数 `OPENAI_API_KEY` に設定）
+
+### インストール
+
+```bash
+git clone https://github.com/your-org/yali.git
+cd yali
+npm install
+npm run build
+npm link
+```
+
+### 30秒サンプル
+
+以下のYAMLファイルを作成します。
+
+```yaml
+# translate.yaml
+name: translate
+model:
+  name: gpt-4o-mini
+  temperature: 0.3
+input:
+  from: args
+  var: input
+prompt: |
+  Translate the following text into Japanese.
+
+  Text: {{input}}
+output:
+  format: text
+  target: stdout
+```
+
+実行：
+
+```bash
+export OPENAI_API_KEY=sk-...
+yali run translate.yaml --input "Hello, world"
+```
+
+出力例：
+
+```
+こんにちは、世界
+```
+
+---
+
+## CLIリファレンス（概要）
+
+```
+yali run <command.yaml> [options]
+
+Options:
+  --input <value|path>   プライマリ入力変数（input.from が "file" の場合はファイルパス）
+  --var <key=value>      テンプレート変数を追加設定（繰り返し指定可）
+  --dry-run              LLMを呼び出さずにプロンプトをレンダリングして確認
+  --format <text|json>   --dry-run 時の出力フォーマット（デフォルト: text）
+  --help                 ヘルプを表示
+```
+
+---
+
+## ドキュメント
+
+詳細なYAMLスキーマ、マルチステップパイプライン、入出力設定などの使い方は、日本語ユーザーガイドを参照してください。
+
+📖 **[docs/user-guide.ja.md](docs/user-guide.ja.md)**
+
+---
+
+## コントリビューション
+
+バグ報告・機能提案・プルリクエストを歓迎します。
+コントリビューション前に必ずご確認ください。
+
+📋 **[CONTRIBUTING.md](CONTRIBUTING.md)**
+
+---
+
+## ライセンス
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,98 @@
 # yali
+
+[![CI](https://img.shields.io/github/actions/workflow/status/your-org/yali/ci.yml?label=CI&style=flat-square)](https://github.com/your-org/yali/actions)
+[![npm](https://img.shields.io/npm/v/yali?style=flat-square)](https://www.npmjs.com/package/yali)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+
+**YAML LLM Interface** — define LLM commands in YAML, run them from the terminal.
+
+---
+
+## Features
+
+- 📄 **YAML-first** — describe prompts, models, and I/O in a single file
+- 🔗 **Multi-step pipelines** — chain steps with `depends_on` and pass outputs between them
+- 📥 **Flexible input** — read from stdin, CLI args, or a file
+- 📤 **Flexible output** — write text, Markdown, or JSON to stdout or a file
+- 🔍 **Dry-run mode** — render and inspect prompts without calling the API
+- 🧩 **Template variables** — inject dynamic values with `{{variable}}` syntax and `--var`
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 20+
+- An OpenAI API key exported as `OPENAI_API_KEY`
+
+### Install
+
+```bash
+git clone https://github.com/your-org/yali.git
+cd yali
+npm install
+npm run build
+npm link          # makes `yali` available globally
+```
+
+### 30-second example
+
+Create `translate.yaml`:
+
+```yaml
+name: translate
+model:
+  name: gpt-4o-mini
+  temperature: 0.3
+input:
+  from: args
+  var: input
+prompt: |
+  Translate the following text into Japanese:
+
+  {{input}}
+output:
+  format: text
+  target: stdout
+```
+
+Run it:
+
+```bash
+yali run translate.yaml --input "Hello, world"
+```
+
+Output:
+
+```
+こんにちは、世界
+```
+
+#### Other useful flags
+
+```
+--var key=value    Set an additional template variable (repeatable)
+--dry-run          Print the rendered prompt without calling the LLM
+--format json      Output dry-run result as JSON
+```
+
+---
+
+## Documentation
+
+Full usage guide, YAML schema reference, and advanced examples:
+
+📖 **[docs/user-guide.md](docs/user-guide.md)**
+
+---
+
+## Contributing
+
+Contributions are welcome! Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** for branch naming conventions, commit style, and the pull-request workflow.
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -1,0 +1,731 @@
+# yali 全機能リファレンス（日本語版）
+
+**yali**（YAML LLM Interface）は、YAMLファイルでLLMコマンドを定義し、ターミナルから実行できるオープンソースCLIツールです。
+
+> 日本語版トップページは [README.ja.md](../README.ja.md) を参照してください。英語版は [README.md](../README.md) と [docs/user-guide.md](./user-guide.md) をご覧ください。
+
+---
+
+## 目次
+
+1. [要件](#要件)
+2. [インストール](#インストール)
+3. [CLIリファレンス](#cliリファレンス)
+4. [YAMLスキーマリファレンス](#yamlスキーマリファレンス)
+5. [入力解決](#入力解決)
+6. [マルチステップパイプライン](#マルチステップパイプライン)
+7. [出力フォーマット](#出力フォーマット)
+8. [ドライラン](#ドライラン)
+9. [使用例](#使用例)
+10. [環境変数](#環境変数)
+11. [エラー対処](#エラー対処)
+
+---
+
+## 要件
+
+| 項目 | 要件 |
+|---|---|
+| Node.js | 20以上 |
+| 環境変数 | `OPENAI_API_KEY`（必須） |
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+---
+
+## インストール
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/your-org/yali.git
+cd yali
+
+# 依存関係をインストール
+npm install
+
+# TypeScriptをビルド
+npm run build
+
+# グローバルにリンク（どこからでも yali コマンドを使用可能）
+npm link
+```
+
+インストール後、以下のコマンドで動作を確認してください。
+
+```bash
+yali --help
+```
+
+---
+
+## CLIリファレンス
+
+```
+Usage: yali run <command.yaml> [options]
+```
+
+### オプション一覧
+
+| オプション | 引数 | 説明 |
+|---|---|---|
+| `--input <value\|path>` | 文字列またはファイルパス | プライマリ入力変数を設定。`input.from` が `file` の場合はファイルパスとして解釈される |
+| `--var <key=value>` | `キー=値` 形式 | 任意のテンプレート変数を設定。複数回指定可能 |
+| `--dry-run` | なし | LLMを呼び出さずにプロンプトのレンダリングのみ行う |
+| `--format <text\|json>` | `text` または `json` | `--dry-run` の出力フォーマット（デフォルト: `text`） |
+| `--help` | なし | ヘルプメッセージを表示 |
+
+### 基本的な使い方
+
+```bash
+# YAMLコマンドを実行（stdin入力）
+echo "Hello, world" | yali run translate.yaml
+
+# --input で値を直接指定
+yali run translate.yaml --input "Hello, world"
+
+# 複数の変数を注入
+yali run summarize.yaml --input "本文..." --var lang=Japanese --var style=formal
+
+# ドライランでプロンプトを確認
+yali run translate.yaml --input "test" --dry-run
+
+# ドライランをJSONで出力
+yali run translate.yaml --input "test" --dry-run --format json
+```
+
+---
+
+## YAMLスキーマリファレンス
+
+### a. 最小構成（prompt + model文字列）
+
+最もシンプルな形式です。`prompt` と `model` のみを指定します。
+
+```yaml
+prompt: "次のテキストを日本語に翻訳してください: {{input}}"
+model: gpt-4o
+```
+
+- `model` を省略した場合のデフォルトは `gpt-4o` です。
+- `input` フィールドを省略した場合、自動的に `{ from: stdin, var: input }` が適用されます。
+
+### b. 標準構成（name, modelオブジェクト, input, output）
+
+```yaml
+name: translate
+version: "1.0"
+
+model:
+  name: gpt-4o
+  temperature: 0.3
+  max_tokens: 2048
+
+prompt: |
+  次のテキストを{{lang}}に翻訳してください。
+
+  テキスト:
+  {{input}}
+
+input:
+  from: stdin
+  var: input
+  default: "(入力なし)"
+
+output:
+  format: text
+  target: stdout
+```
+
+### c. マルチステップ構成（steps配列とdepends_on）
+
+```yaml
+name: summarize-and-translate
+
+steps:
+  - id: summarize
+    model: gpt-4o
+    prompt: |
+      以下のテキストを3文以内で要約してください。
+
+      テキスト:
+      {{input}}
+
+  - id: translate
+    model: gpt-4o-mini
+    depends_on:
+      - summarize
+    prompt: |
+      次の文章を英語に翻訳してください。
+
+      {{steps.summarize.output}}
+
+input:
+  from: stdin
+  var: input
+
+output:
+  format: text
+  target: stdout
+```
+
+### d. トップレベルフィールド参照表
+
+| フィールド | 型 | 省略可否 | 説明 |
+|---|---|---|---|
+| `name` | 文字列 | 省略可 | コマンド名 |
+| `version` | 文字列 | 省略可 | バージョン文字列 |
+| `prompt` | 文字列 | `steps`と排他 | シングルステップ省略記法 |
+| `model` | 文字列またはModelSpec | 省略可 | `prompt`省略記法で使用。デフォルト: `gpt-4o` |
+| `steps` | Step配列 | `prompt`と排他 | マルチステップモード |
+| `input` | InputSpec | 省略可 | 入力設定 |
+| `output` | OutputSpec | 省略可 | 出力設定 |
+| `tools` | ToolSpec[] | 省略可 | ツール仕様（MCP、将来対応） |
+
+### e. ModelSpecフィールド参照表
+
+`model` フィールドには文字列またはオブジェクト（ModelSpec）を指定できます。
+
+```yaml
+# 文字列形式
+model: gpt-4o
+
+# オブジェクト形式（ModelSpec）
+model:
+  name: gpt-4o
+  temperature: 0.7
+  max_tokens: 1024
+```
+
+| フィールド | 型 | 省略可否 | 説明 |
+|---|---|---|---|
+| `name` | 文字列 | **必須** | モデル名（例: `gpt-4o`, `gpt-4o-mini`） |
+| `temperature` | 浮動小数点 | 省略可 | サンプリング温度（0.0〜2.0） |
+| `max_tokens` | 整数 | 省略可 | 最大生成トークン数 |
+
+### f. InputSpecフィールド参照表
+
+```yaml
+input:
+  from: stdin        # stdin | args | file
+  var: input         # テンプレート内の変数名
+  default: "(なし)"  # 入力がない場合のデフォルト値
+  path: ./data.txt   # from: file の場合のパス（省略可）
+```
+
+| フィールド | 型 | 省略可否 | 説明 |
+|---|---|---|---|
+| `from` | `stdin` \| `args` \| `file` | **必須** | 入力ソース |
+| `var` | 文字列 | **必須** | プロンプトテンプレート内の変数名 |
+| `default` | 文字列 | 省略可 | 入力がない場合のデフォルト値 |
+| `path` | 文字列 | 省略可 | `from: file` で `--input` が指定されない場合のファイルパス |
+
+### g. OutputSpecフィールド参照表
+
+```yaml
+output:
+  format: text       # text | markdown | json
+  target: stdout     # stdout | file
+  path: ./out.txt    # target: file の場合に必須
+```
+
+| フィールド | 型 | 省略可否 | 説明 |
+|---|---|---|---|
+| `format` | `text` \| `markdown` \| `json` | **必須** | 出力フォーマット |
+| `target` | `stdout` \| `file` | **必須** | 出力先 |
+| `path` | 文字列 | 条件付き必須 | `target: file` の場合に必須のファイルパス |
+
+### h. Stepフィールド参照表
+
+`steps` 配列の各要素に指定するフィールドです。
+
+| フィールド | 型 | 省略可否 | 説明 |
+|---|---|---|---|
+| `id` | 文字列 | **必須** | ステップの一意な識別子 |
+| `prompt` | 文字列 | **必須** | `{{変数}}`参照を含むプロンプトテンプレート |
+| `model` | 文字列またはModelSpec | **必須** | このステップで使用するモデル |
+| `depends_on` | 文字列[] | 省略可 | 先行して完了すべきステップのIDリスト（デフォルト: `[]`） |
+
+---
+
+## 入力解決
+
+yaliは以下の優先順位で入力変数を解決します（高い順）。
+
+| 優先順位 | ソース | 方法 |
+|---|---|---|
+| 1（最高） | `--var key=value` フラグ | 任意の変数を直接指定 |
+| 2 | `from: args` | `--input <値>` をそのまま使用 |
+| 3 | `from: stdin` | パイプされたstdinテキスト |
+| 3 | `from: file` | `--input <パス>` でファイルを読み込み |
+| 4（最低） | `input.default` | YAMLに定義されたデフォルト値 |
+
+### 各入力モードの例
+
+#### from: stdin（パイプ入力）
+
+```yaml
+input:
+  from: stdin
+  var: input
+```
+
+```bash
+echo "翻訳するテキスト" | yali run translate.yaml
+cat document.txt | yali run summarize.yaml
+```
+
+#### from: args（直接値指定）
+
+```yaml
+input:
+  from: args
+  var: input
+```
+
+```bash
+yali run translate.yaml --input "翻訳するテキスト"
+```
+
+#### from: file（ファイル読み込み）
+
+```yaml
+input:
+  from: file
+  var: content
+  path: ./default-input.txt  # --input 未指定時のフォールバック
+```
+
+```bash
+# ファイルパスを直接指定
+yali run summarize.yaml --input ./report.txt
+
+# --input 省略時は YAML の path を使用
+yali run summarize.yaml
+```
+
+#### --var による変数注入
+
+`--var` は `input` 変数以外の任意の変数を上書き・追加できます。
+
+```bash
+yali run translate.yaml --input "Hello" --var lang=French --var style=formal
+```
+
+対応するYAML:
+
+```yaml
+prompt: |
+  次のテキストを{{lang}}に{{style}}なスタイルで翻訳してください。
+
+  テキスト: {{input}}
+model: gpt-4o
+```
+
+---
+
+## マルチステップパイプライン
+
+### 仕組み
+
+`steps` 配列を使用すると、複数のLLM呼び出しを連鎖させられます。
+
+- **`depends_on`**: 依存するステップのIDを指定します。依存ステップが完了してから当該ステップが実行されます。
+- **実行順序**: Kahnのアルゴリズムによるトポロジカルソートで決定されます。依存関係のないステップは先に実行されます。
+- **ステップ出力の参照**: 前のステップの出力は `{{steps.<id>.output}}` でアクセスできます。
+
+### 実行フロー
+
+```
+step A（depends_on: []）
+    ↓ 完了
+step B（depends_on: [A]）
+    ↓ 完了
+step C（depends_on: [A, B]）
+```
+
+依存関係のないステップは並列実行ではなく、トポロジカル順で逐次実行されます。
+
+### マルチステップYAML例
+
+```yaml
+name: research-and-report
+
+steps:
+  - id: extract
+    model: gpt-4o
+    prompt: |
+      以下の文書から重要なキーワードを10個抽出してください。
+
+      文書:
+      {{input}}
+
+  - id: summarize
+    model: gpt-4o
+    depends_on:
+      - extract
+    prompt: |
+      以下のキーワードに基づいて、文書の要旨を200字以内でまとめてください。
+
+      キーワード:
+      {{steps.extract.output}}
+
+      元の文書:
+      {{input}}
+
+  - id: report
+    model: gpt-4o-mini
+    depends_on:
+      - extract
+      - summarize
+    prompt: |
+      以下の情報を使って、最終レポートを作成してください。
+
+      要旨: {{steps.summarize.output}}
+      キーワード: {{steps.extract.output}}
+
+input:
+  from: stdin
+  var: input
+
+output:
+  format: markdown
+  target: stdout
+```
+
+```bash
+cat research-paper.txt | yali run research-and-report.yaml
+```
+
+---
+
+## 出力フォーマット
+
+`output.format` で出力形式を制御します。
+
+| フォーマット | 説明 | 用途 |
+|---|---|---|
+| `text` | プレーンテキスト（デフォルト） | 一般的なテキスト出力 |
+| `markdown` | Markdownテキスト | ドキュメント生成 |
+| `json` | JSON形式 | プログラムによる後処理 |
+
+`text` と `markdown` の場合、出力はstdoutにストリーミングされます。`json` またはターゲットが `file` の場合はストリーミングされません。
+
+### UNIXパイプ連携例（json + jq）
+
+```yaml
+name: analyze
+prompt: |
+  以下のテキストを分析し、JSON形式で返してください。
+  { "sentiment": "positive|negative|neutral", "score": 0.0-1.0, "summary": "..." }
+
+  テキスト: {{input}}
+model: gpt-4o
+output:
+  format: json
+  target: stdout
+```
+
+```bash
+# jq でフィールドを抽出
+echo "素晴らしい製品です！" | yali run analyze.yaml | jq '.sentiment'
+
+# 複数ファイルをバッチ処理
+for f in reviews/*.txt; do
+  cat "$f" | yali run analyze.yaml | jq -c '{file: "'"$f"'", sentiment: .sentiment}'
+done
+```
+
+### ファイルへの出力
+
+```yaml
+output:
+  format: markdown
+  target: file
+  path: ./output/report.md
+```
+
+```bash
+cat article.txt | yali run summarize.yaml
+# 結果は ./output/report.md に保存される
+```
+
+---
+
+## ドライラン
+
+`--dry-run` フラグを使うと、LLM APIを呼び出さずにプロンプトのレンダリング結果を確認できます。APIキーを消費しないため、YAMLの検証やデバッグに便利です。
+
+### テキスト形式（デフォルト）
+
+人間が読みやすい形式で出力されます。
+
+```bash
+yali run translate.yaml --input "Hello, world" --dry-run
+```
+
+出力例:
+
+```
+=== Step: step0 (model: gpt-4o) ===
+次のテキストを日本語に翻訳してください: Hello, world
+```
+
+### マルチステップのドライラン
+
+ドライランでは各ステップのプロンプトをトポロジカル順にレンダリングします。ただし、ドライランではLLMが呼び出されないため、**ステップ間の出力参照（`{{steps.<id>.output}}`）は利用できません**。後続ステップのプロンプトが `{{steps.<id>.output}}` を参照している場合、ドライランは `RenderError` で終了します。
+
+ドライランが有効なのは、各ステップのプロンプトが `{{input}}` や `--var` で提供された変数のみを参照している場合です：
+
+```bash
+# 有効: シングルステップ、またはステップ間参照のないマルチステップ
+yali run translate.yaml --input "Hello" --dry-run
+
+# --var でステップ出力を模擬することも可能
+yali run pipeline.yaml --input "Hello" \
+  --var "steps.step_a.output=模擬出力テキスト" \
+  --dry-run --format json
+```
+
+### JSON形式（機械向け）
+
+```bash
+yali run translate.yaml --input "Hello, world" --dry-run --format json
+```
+
+出力例:
+
+```json
+{
+  "steps": [
+    {
+      "id": "step0",
+      "prompt": "次のテキストを日本語に翻訳してください: Hello, world",
+      "model": { "name": "gpt-4o" },
+      "depends_on": []
+    }
+  ]
+}
+```
+
+---
+
+## 使用例
+
+### 例1: シンプルな翻訳（stdin入力）
+
+`translate.yaml`:
+
+```yaml
+name: translate
+prompt: |
+  次のテキストを日本語に翻訳してください。自然な日本語で翻訳し、翻訳結果のみを出力してください。
+
+  テキスト:
+  {{input}}
+model:
+  name: gpt-4o
+  temperature: 0.3
+input:
+  from: stdin
+  var: input
+output:
+  format: text
+  target: stdout
+```
+
+```bash
+echo "The quick brown fox jumps over the lazy dog." | yali run translate.yaml
+```
+
+### 例2: ファイル入力での要約
+
+`summarize.yaml`:
+
+```yaml
+name: summarize
+prompt: |
+  以下の文書を読み、3〜5文で簡潔に要約してください。
+
+  文書:
+  {{content}}
+model:
+  name: gpt-4o
+  max_tokens: 512
+input:
+  from: file
+  var: content
+output:
+  format: text
+  target: stdout
+```
+
+```bash
+yali run summarize.yaml --input ./report.pdf.txt
+```
+
+### 例3: --varによる変数注入
+
+`translate-custom.yaml`:
+
+```yaml
+name: translate-custom
+prompt: |
+  次のテキストを{{target_lang}}に翻訳してください。
+  トーン: {{tone}}
+  翻訳結果のみを出力してください。
+
+  テキスト:
+  {{input}}
+model: gpt-4o
+input:
+  from: args
+  var: input
+output:
+  format: text
+  target: stdout
+```
+
+```bash
+yali run translate-custom.yaml \
+  --input "人工知能は私たちの生活を変えています。" \
+  --var target_lang=English \
+  --var tone=academic
+```
+
+### 例4: マルチステップ — 要約してから翻訳
+
+`summarize-then-translate.yaml`:
+
+```yaml
+name: summarize-then-translate
+
+steps:
+  - id: summarize
+    model:
+      name: gpt-4o
+      temperature: 0.5
+    prompt: |
+      以下の長文を200字以内で要約してください。要約のみを出力してください。
+
+      文書:
+      {{input}}
+
+  - id: translate
+    model:
+      name: gpt-4o-mini
+      temperature: 0.3
+    depends_on:
+      - summarize
+    prompt: |
+      次の日本語テキストを英語に翻訳してください。翻訳結果のみを出力してください。
+
+      {{steps.summarize.output}}
+
+input:
+  from: stdin
+  var: input
+
+output:
+  format: text
+  target: stdout
+```
+
+```bash
+cat long-article.txt | yali run summarize-then-translate.yaml
+```
+
+ドライランで確認:
+
+```bash
+cat long-article.txt | yali run summarize-then-translate.yaml --dry-run
+```
+
+---
+
+## 環境変数
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `OPENAI_API_KEY` | **必須** | OpenAI APIキー。未設定の場合はエラーで終了します。 |
+
+```bash
+# シェルセッションで設定
+export OPENAI_API_KEY="sk-..."
+
+# .env ファイルを使う場合（dotenvなどを使用）
+echo 'OPENAI_API_KEY=sk-...' > .env
+```
+
+> **セキュリティ上の注意**: APIキーをYAMLファイルやソースコードに直接記載しないでください。必ず環境変数で管理してください。
+
+---
+
+## エラー対処
+
+### 終了コード
+
+| コード | 意味 |
+|---|---|
+| `0` | 正常終了 |
+| `1` | エラー終了（詳細はstderrに出力） |
+
+### よくあるエラーと対処法
+
+#### `OPENAI_API_KEY` が未設定
+
+```
+Error: OPENAI_API_KEY environment variable is not set.
+```
+
+**対処**: `export OPENAI_API_KEY="sk-..."` を実行してください。
+
+#### YAMLファイルが見つからない
+
+```
+Error: Cannot find YAML file: ./translate.yaml
+```
+
+**対処**: ファイルパスが正しいか確認してください。
+
+#### テンプレート変数が見つからない（RenderError）
+
+```
+RenderError: Variable "lang" is not defined.
+```
+
+**対処**: YAMLの `prompt` 内で参照している変数が、`input.var` または `--var` で提供されているか確認してください。
+
+#### レート制限エラー（HTTP 429）
+
+yaliは指数バックオフで最大3回リトライします（HTTP 408/429/500/502/503/504およびネットワークエラー）。リトライ後も失敗した場合:
+
+```
+Error: OpenAI API rate limit exceeded after 3 retries.
+```
+
+**対処**: しばらく待ってから再試行するか、`model.max_tokens` を削減してリクエストサイズを小さくしてください。
+
+#### `prompt` と `steps` の同時指定
+
+```
+Error: Cannot specify both "prompt" and "steps" in the same YAML file.
+```
+
+**対処**: シングルステップには `prompt` を、マルチステップには `steps` を使用し、両方を同時に指定しないでください。
+
+#### `target: file` で `path` が未指定
+
+```
+Error: output.path is required when output.target is "file".
+```
+
+**対処**: YAMLの `output` セクションに `path` フィールドを追加してください。
+
+### デバッグのヒント
+
+1. `--dry-run` でプロンプトのレンダリング結果を確認する。
+2. `--dry-run --format json` で機械可読な形式で確認する。
+3. シンプルな最小構成のYAMLから始めて、徐々にフィールドを追加する。
+4. `--var` で変数を上書きして、テンプレートの動作を確認する。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,783 @@
+# yali User Guide
+
+**yali** (YAML LLM Interface) is an open-source CLI tool that lets you define LLM commands in YAML and run them from the terminal. You describe your prompt, model, input, and output declaratively — yali handles template rendering, API calls, retries, and output formatting.
+
+→ See the [README](../README.md) for a quick overview and motivation.
+
+---
+
+## Table of Contents
+
+1. [Requirements](#requirements)
+2. [Installation](#installation)
+3. [CLI Reference](#cli-reference)
+4. [YAML Schema Reference](#yaml-schema-reference)
+5. [Input Resolution](#input-resolution)
+6. [Multi-step Pipelines](#multi-step-pipelines)
+7. [Output Formats](#output-formats)
+8. [Dry Run](#dry-run)
+9. [Examples](#examples)
+10. [Environment Variables](#environment-variables)
+11. [Error Handling](#error-handling)
+
+---
+
+## Requirements
+
+| Requirement | Details |
+|---|---|
+| **Node.js** | Version 20 or later |
+| **npm** | Bundled with Node.js |
+| **OPENAI_API_KEY** | Required environment variable for all LLM calls (see [Environment Variables](#environment-variables)) |
+
+---
+
+## Installation
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/your-org/yali.git
+cd yali
+
+# 2. Install dependencies
+npm install
+
+# 3. Build the project
+npm run build
+
+# 4. (Optional) Link globally so `yali` is available from anywhere
+npm link
+```
+
+After linking, verify the installation:
+
+```bash
+yali --help
+```
+
+---
+
+## CLI Reference
+
+### Synopsis
+
+```
+yali run <command.yaml> [options]
+```
+
+### Options
+
+| Option | Argument | Description |
+|---|---|---|
+| `--input <value\|path>` | string | Sets the primary input variable. Behavior depends on `input.from` in the YAML: with `from: args`, the value is used directly; with `from: file`, the value is treated as a file path to read. |
+| `--var <key=value>` | `key=value` | Sets an arbitrary template variable. Repeatable — pass multiple `--var` flags for multiple variables. Takes the highest resolution priority (see [Input Resolution](#input-resolution)). |
+| `--dry-run` | — | Renders all prompts without calling the LLM API. Useful for inspecting expanded templates before running. |
+| `--format <text\|json>` | `text` or `json` | Controls the output format for `--dry-run`. Defaults to `text`. Has no effect without `--dry-run`. |
+| `--help` | — | Prints the help message and exits. |
+
+### Basic usage
+
+```bash
+# Run a command file with piped stdin
+echo "Hello, world" | yali run translate.yaml
+
+# Run with explicit --input value
+yali run translate.yaml --input "Hello, world"
+
+# Run with a file as input
+yali run summarize.yaml --input ./article.txt
+
+# Inject template variables
+yali run greet.yaml --var name=Alice --var lang=French
+
+# Preview rendered prompts without calling the LLM
+yali run pipeline.yaml --input "some text" --dry-run
+
+# Preview as JSON (machine-readable)
+yali run pipeline.yaml --input "some text" --dry-run --format json
+```
+
+---
+
+## YAML Schema Reference
+
+yali command files are standard YAML documents. All fields are optional unless marked required.
+
+### Top-level fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Human-readable name for the command |
+| `version` | string | No | Version string for the command file |
+| `prompt` | string | No | Single-step shorthand. Mutually exclusive with `steps`. |
+| `model` | string or ModelSpec | No | Model to use with the `prompt` shorthand. Defaults to `gpt-4o`. |
+| `steps` | Step[] | No | Multi-step mode. Mutually exclusive with `prompt`. |
+| `input` | InputSpec | No | Input configuration. Defaults to `{ from: stdin, var: input }`. |
+| `output` | OutputSpec | No | Output configuration. Defaults to `{ format: text, target: stdout }`. |
+| `tools` | ToolSpec[] | No | Tool specifications (MCP integration — reserved for future use). |
+
+> **Note:** You must provide either `prompt` or `steps`, but not both.
+
+---
+
+### a. Minimal configuration
+
+The simplest possible command: a single prompt using the default model, reading from stdin.
+
+```yaml
+prompt: "Translate the following text to French:\n\n{{input}}"
+```
+
+Run it:
+
+```bash
+echo "Good morning" | yali run translate.yaml
+```
+
+---
+
+### b. Standard configuration
+
+A fully-specified single-step command with explicit name, model parameters, input source, and output destination.
+
+```yaml
+name: Article Summarizer
+version: "1.0"
+
+model:
+  name: gpt-4o
+  temperature: 0.3
+  max_tokens: 512
+
+prompt: |
+  Summarize the following article in 3 bullet points:
+
+  {{input}}
+
+input:
+  from: file
+  var: input
+
+output:
+  format: markdown
+  target: stdout
+```
+
+Run it:
+
+```bash
+yali run summarize.yaml --input ./article.txt
+```
+
+---
+
+### c. Multi-step configuration
+
+A pipeline where each step can depend on the outputs of previous steps.
+
+```yaml
+name: Summarize and Translate
+
+input:
+  from: stdin
+  var: article
+
+output:
+  format: text
+  target: stdout
+
+steps:
+  - id: summarize
+    model: gpt-4o
+    depends_on: []
+    prompt: |
+      Summarize the following article in 3 sentences:
+
+      {{article}}
+
+  - id: translate
+    model: gpt-4o
+    depends_on: [summarize]
+    prompt: |
+      Translate the following summary to Spanish:
+
+      {{steps.summarize.output}}
+```
+
+Run it:
+
+```bash
+cat article.txt | yali run pipeline.yaml
+```
+
+---
+
+### ModelSpec
+
+Used for the top-level `model` field or the `model` field inside each Step.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | **Yes** | Model identifier (e.g. `gpt-4o`, `gpt-4o-mini`) |
+| `temperature` | float | No | Sampling temperature. Higher values produce more varied output. |
+| `max_tokens` | int | No | Maximum number of tokens to generate in the response. |
+
+**String shorthand** — you can also write `model: gpt-4o` instead of the full object form:
+
+```yaml
+# Shorthand
+model: gpt-4o
+
+# Equivalent object form
+model:
+  name: gpt-4o
+```
+
+---
+
+### InputSpec
+
+Controls how the primary `{{input}}` variable (or the variable named in `var`) is sourced.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `from` | `stdin` \| `args` \| `file` | **Yes** | Input source mode |
+| `var` | string | **Yes** | Template variable name to bind the input to (e.g. `input`, `article`) |
+| `default` | string | No | Fallback value used when no input is provided from the source |
+| `path` | string | No | File path — used when `from: file` and `--input` is not passed on the CLI |
+
+**`from` modes:**
+
+| Mode | Behavior |
+|---|---|
+| `stdin` | Reads from piped stdin (e.g. `echo "text" \| yali run ...`) |
+| `args` | Reads from the `--input <value>` CLI flag directly |
+| `file` | Reads a file; path comes from `--input <path>` or `input.path` in YAML |
+
+---
+
+### OutputSpec
+
+Controls how the final step's output is formatted and where it is sent.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `format` | `text` \| `markdown` \| `json` | **Yes** | Output format |
+| `target` | `stdout` \| `file` | **Yes** | Output destination |
+| `path` | string | Conditional | Required when `target: file`. Specifies the file path to write to. |
+
+**`format` values:**
+
+| Value | Behavior |
+|---|---|
+| `text` | Raw LLM response, streamed to stdout as-is |
+| `markdown` | Same as `text` — streamed as-is; signals to consumers that the content is Markdown |
+| `json` | Extracts JSON from markdown code fences if present, then pretty-prints the JSON |
+
+**Writing to a file:**
+
+```yaml
+output:
+  format: text
+  target: file
+  path: ./output/result.txt
+```
+
+---
+
+## Input Resolution
+
+When yali resolves a template variable, it follows a strict priority order from highest to lowest:
+
+| Priority | Source | How to use |
+|---|---|---|
+| **1 (highest)** | `--var key=value` CLI flags | `yali run cmd.yaml --var myvar=hello` |
+| **2** | Primary input source (`input.from: args`) | `yali run cmd.yaml --input "hello"` |
+| **3** | Primary input source (`input.from: stdin` or `from: file`) | `echo "hello" \| yali run cmd.yaml` or `yali run cmd.yaml --input ./file.txt` |
+| **4 (lowest)** | Default value from YAML (`input.default`) | Fallback when no other source provides a value |
+
+### Examples
+
+**Overriding input with `--var`:**
+
+Even if the command reads from stdin, `--var` always wins:
+
+```bash
+echo "this is ignored" | yali run cmd.yaml --var input="this is used"
+```
+
+**Reading from stdin (`from: stdin`):**
+
+```yaml
+input:
+  from: stdin
+  var: input
+```
+
+```bash
+echo "Good morning" | yali run translate.yaml
+```
+
+**Reading from CLI args (`from: args`):**
+
+```yaml
+input:
+  from: args
+  var: input
+```
+
+```bash
+yali run translate.yaml --input "Good morning"
+```
+
+**Reading from a file (`from: file`):**
+
+```yaml
+input:
+  from: file
+  var: input
+  path: ./default-article.txt   # used if --input is not provided
+```
+
+```bash
+# Use the path from --input
+yali run summarize.yaml --input ./my-article.txt
+
+# Fall back to path in YAML (default-article.txt)
+yali run summarize.yaml
+```
+
+**Using a default value:**
+
+```yaml
+input:
+  from: args
+  var: lang
+  default: French
+```
+
+```bash
+# Uses "French" as the default when --input is omitted
+yali run translate.yaml
+```
+
+**Injecting multiple variables with `--var`:**
+
+```yaml
+prompt: "Write a {{tone}} email to {{recipient}} about {{topic}}."
+```
+
+```bash
+yali run email.yaml --var tone=formal --var recipient=Alice --var topic="project update"
+```
+
+---
+
+## Multi-step Pipelines
+
+Multi-step mode lets you chain LLM calls, where each step can consume the output of earlier steps.
+
+### How it works
+
+1. yali performs a **topological sort** of your steps using Kahn's algorithm, respecting `depends_on` declarations.
+2. Steps are **executed sequentially** in topological order.
+3. Each step's output is available to subsequent steps as `{{steps.<id>.output}}`.
+
+### `depends_on`
+
+```yaml
+steps:
+  - id: step_a
+    depends_on: []      # no dependencies — runs first
+    ...
+
+  - id: step_b
+    depends_on: [step_a]   # runs after step_a completes
+    prompt: "Process this: {{steps.step_a.output}}"
+    ...
+```
+
+- `depends_on` accepts a list of step `id` strings.
+- Steps with no `depends_on` (or an empty list) are entry points.
+- Circular dependencies will cause an error.
+
+### Accessing step outputs
+
+Use `{{steps.<id>.output}}` in any prompt that declares a dependency on that step:
+
+```yaml
+steps:
+  - id: extract
+    model: gpt-4o
+    prompt: "Extract key facts from:\n\n{{input}}"
+
+  - id: format
+    model: gpt-4o
+    depends_on: [extract]
+    prompt: |
+      Format the following facts as a numbered list:
+
+      {{steps.extract.output}}
+```
+
+### Complete multi-step example
+
+```yaml
+name: Research Pipeline
+
+input:
+  from: stdin
+  var: query
+
+output:
+  format: markdown
+  target: stdout
+
+steps:
+  - id: research
+    model:
+      name: gpt-4o
+      temperature: 0.5
+    depends_on: []
+    prompt: |
+      You are a research assistant. Provide a detailed answer to:
+
+      {{query}}
+
+  - id: critique
+    model: gpt-4o
+    depends_on: [research]
+    prompt: |
+      Critically evaluate the following research answer and identify any gaps:
+
+      {{steps.research.output}}
+
+  - id: final
+    model:
+      name: gpt-4o
+      temperature: 0.2
+    depends_on: [research, critique]
+    prompt: |
+      Given this research:
+      {{steps.research.output}}
+
+      And this critique:
+      {{steps.critique.output}}
+
+      Produce a refined, comprehensive answer.
+```
+
+```bash
+echo "What are the main causes of inflation?" | yali run research.yaml
+```
+
+---
+
+## Output Formats
+
+The `output.format` field controls how yali processes and presents the LLM's response.
+
+| Format | Behavior |
+|---|---|
+| `text` | Streams the raw LLM response to stdout. No post-processing. |
+| `markdown` | Streams the raw LLM response to stdout. Semantically indicates Markdown content for downstream consumers. |
+| `json` | Extracts JSON from markdown code fences (` ```json ... ``` `) if present, then pretty-prints the JSON. Streaming is disabled in JSON mode. |
+
+### UNIX pipe integration
+
+yali's `json` output format works well with tools like `jq`:
+
+```yaml
+# data-extractor.yaml
+prompt: |
+  Extract the author, title, and publication year from the text below.
+  Respond with valid JSON only.
+
+  {{input}}
+
+output:
+  format: json
+  target: stdout
+```
+
+```bash
+echo "The Great Gatsby by F. Scott Fitzgerald, published in 1925." \
+  | yali run data-extractor.yaml \
+  | jq '.author'
+```
+
+### Writing output to a file
+
+```yaml
+output:
+  format: text
+  target: file
+  path: ./result.txt
+```
+
+When `target: file`, streaming is disabled and the complete response is written to the specified path.
+
+---
+
+## Dry Run
+
+The `--dry-run` flag renders all prompts with variables fully expanded, but **does not call the LLM API**. No API key is needed for a dry run.
+
+Use it to:
+- Verify that template variables are resolved correctly
+- Inspect the final prompts before incurring API costs
+- Debug multi-step pipelines
+
+### Text format (default)
+
+Human-readable output — one section per step:
+
+```bash
+yali run pipeline.yaml --input "Hello" --dry-run
+```
+
+Output:
+
+```
+=== Step: step0 (model: gpt-4o) ===
+Translate the following text to French:
+
+Hello
+```
+
+### JSON format
+
+Machine-readable output — useful for programmatic inspection or CI pipelines:
+
+```bash
+yali run pipeline.yaml --input "Hello" --dry-run --format json
+```
+
+Output:
+
+```json
+{
+  "steps": [
+    {
+      "id": "step0",
+      "model": "gpt-4o",
+      "depends_on": [],
+      "prompt": "Translate the following text to French:\n\nHello"
+    }
+  ]
+}
+```
+
+### Multi-step dry run
+
+Dry run renders each step's prompt in topological order. Note that **inter-step output references (`{{steps.<id>.output}}`) are not available** during dry run, since no LLM calls are made. If any step prompt references `{{steps.<id>.output}}`, the dry run will exit with a `RenderError`.
+
+Dry run works well for pipelines where steps only reference `{{input}}` or `--var` variables:
+
+```bash
+# Works: single-step or multi-step without inter-step output refs
+yali run translate.yaml --input "Hello" --dry-run
+
+# Also works: pre-supply step outputs via --var
+yali run pipeline.yaml --input "Hello" \
+  --var "steps.step_a.output=simulated output" \
+  --dry-run --format json
+```
+
+---
+
+## Examples
+
+### a. Simple translation (stdin input)
+
+**`translate.yaml`:**
+
+```yaml
+name: Translator
+model: gpt-4o
+
+prompt: |
+  Translate the following text to French:
+
+  {{input}}
+
+input:
+  from: stdin
+  var: input
+
+output:
+  format: text
+  target: stdout
+```
+
+**Usage:**
+
+```bash
+echo "The weather is beautiful today." | yali run translate.yaml
+```
+
+---
+
+### b. Summarization with file input
+
+**`summarize.yaml`:**
+
+```yaml
+name: Article Summarizer
+
+model:
+  name: gpt-4o
+  temperature: 0.2
+  max_tokens: 256
+
+prompt: |
+  Summarize the following article in 3 concise bullet points:
+
+  {{article}}
+
+input:
+  from: file
+  var: article
+
+output:
+  format: markdown
+  target: stdout
+```
+
+**Usage:**
+
+```bash
+yali run summarize.yaml --input ./news-article.txt
+```
+
+---
+
+### c. Variable injection with `--var`
+
+**`email.yaml`:**
+
+```yaml
+name: Email Composer
+
+model: gpt-4o-mini
+
+prompt: |
+  Write a {{tone}} email to {{recipient}} about: {{topic}}.
+  Keep it under 150 words.
+
+output:
+  format: text
+  target: stdout
+```
+
+**Usage:**
+
+```bash
+yali run email.yaml \
+  --var tone=friendly \
+  --var recipient="the team" \
+  --var topic="Friday's product launch"
+```
+
+---
+
+### d. Multi-step: summarize then translate
+
+**`summarize-and-translate.yaml`:**
+
+```yaml
+name: Summarize and Translate
+
+input:
+  from: file
+  var: article
+
+output:
+  format: text
+  target: stdout
+
+steps:
+  - id: summarize
+    model:
+      name: gpt-4o
+      temperature: 0.2
+    depends_on: []
+    prompt: |
+      Summarize the following article in 2-3 sentences:
+
+      {{article}}
+
+  - id: translate
+    model: gpt-4o
+    depends_on: [summarize]
+    prompt: |
+      Translate the following English summary into Japanese:
+
+      {{steps.summarize.output}}
+```
+
+**Usage:**
+
+```bash
+yali run summarize-and-translate.yaml --input ./report.txt
+```
+
+**Dry-run check first:**
+
+```bash
+yali run summarize-and-translate.yaml --input ./report.txt --dry-run
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | **Yes** | Your OpenAI API key. Required for all LLM calls. Not needed for `--dry-run`. |
+
+### Setting the API key
+
+```bash
+# Inline (current shell only)
+export OPENAI_API_KEY=sk-...
+
+# Or add to your shell profile for persistence
+echo 'export OPENAI_API_KEY=sk-...' >> ~/.bashrc
+source ~/.bashrc
+```
+
+> **Security:** Never commit your API key to source control. Use environment variables or a secrets manager.
+
+---
+
+## Error Handling
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Error (parse failure, render failure, API error, etc.) |
+
+### Common errors
+
+| Error | Cause | Resolution |
+|---|---|---|
+| `OPENAI_API_KEY is not set` | The environment variable is missing | Export `OPENAI_API_KEY` before running |
+| `RenderError: variable '{{name}}' not found` | A template references a variable that was not provided | Pass the variable via `--var name=value` or check your `input` spec |
+| `YAML parse error` | The command file contains invalid YAML syntax | Validate your YAML with a linter |
+| `Circular dependency detected` | A multi-step pipeline has a cycle in `depends_on` | Review and remove the circular reference |
+| `step id not found in depends_on` | A step references an undefined step ID | Verify all `depends_on` IDs match existing step `id` values |
+| API `429 Too Many Requests` | Rate limit exceeded | yali retries automatically (up to 3 times with exponential backoff); reduce request rate if retries are exhausted |
+| API `5xx` errors | Transient server error | yali retries automatically on 500, 502, 503, 504 with exponential backoff |
+
+### Retry behaviour
+
+yali automatically retries failed API calls using exponential backoff:
+
+- **Max retries:** 3
+- **Retryable status codes:** 408, 429, 500, 502, 503, 504
+- **Also retries on:** network-level errors (connection reset, timeout, etc.)
+
+If all retries are exhausted, yali exits with code `1` and prints the error to stderr.


### PR DESCRIPTION
## Summary

Add comprehensive documentation for all yali CLI features, structured as:

- **README.md** (rewritten): OSS cover page — overview, features, quick start, links to full docs
- **README.ja.md** (new): Japanese OSS cover page
- **docs/user-guide.md** (new): Full English user guide
- **docs/user-guide.ja.md** (new): Full Japanese user guide

## What's documented

- CLI reference: all options (\--input\, \--var\, \--dry-run\, \--format\, \--help\)
- YAML schema: all fields across 3 configuration tiers (minimal / standard / multi-step)
- ModelSpec, InputSpec, OutputSpec field reference tables
- Input resolution priority order
- Multi-step pipeline mechanics (\depends_on\, \{{steps.X.output}}\, topological execution)
- Output formats (text/markdown/json) and UNIX pipe integration
- Dry-run mode and its limitations with multi-step inter-step references
- 4 real-world examples
- Environment variables and error handling

## Notes

- Documentation is based on the current \main\ branch source code (Parser + Renderer + Executor + CLI layers)
- YAML examples are verified against the parser schema (\src/parser/schema.ts\)
- Dry-run multi-step limitation is accurately documented (inter-step output refs cause RenderError)