### PR TITLE
fix: smoke test fixes + Windows encoding improvements

### DIFF
--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -91,21 +91,34 @@ output:
 ### Input Resolution Order (highest priority first)
 
 ```
-1. CLI arguments (--var key=value)
-2. stdin (text piped in)
-3. File (input.from: file, input.path: ./data.txt)
-4. Default value defined inline in YAML (input.default: "...")
+1.   CLI arguments (--var key=value)
+1.5. --input-file <path>  (reads file directly as UTF-8; overrides stdin/args/file sources)
+2.   stdin (text piped in) — when input.from: stdin and stdin is piped
+2a.  --input "<value>"    — fallback when input.from: stdin but no pipe is available
+3.   File (input.from: file, input.path: ./data.txt)
+4.   Default value defined inline in YAML (input.default: "...")
 ```
 
 Higher-priority sources override lower-priority ones for the same variable name (following standard CLI convention).
+
+> **Note on `--input-file`:** When Windows PowerShell pipes non-ASCII text to external processes,
+> the default `$OutputEncoding` (ASCII) corrupts multibyte characters. The `--input-file` flag
+> reads the file directly inside Node.js as UTF-8, completely bypassing the pipe. It applies
+> regardless of `input.from` and has higher priority than stdin/args/file sources but lower than
+> `--var`.
+
+> **Note on `from: stdin` → `--input` fallback:** When `input.from: stdin` is specified but no
+> stdin is piped (e.g., during `--dry-run` testing or interactive use), `--input "<value>"` may
+> be provided as a convenience fallback. This allows dry-run testing without requiring a pipe.
 
 ### Variable Mapping Rules
 
 | YAML Definition | Template Variable | Input Source |
 |---|---|---|
-| `input.from: stdin` | `{{input}}` | Full text from pipe |
+| `input.from: stdin` | `{{input}}` | Full text from pipe; falls back to `--input` when not piped |
 | `input.from: args` | `{{input}}` | `yali run cmd.yaml --input "..."` |
-| `input.from: file` | `{{input}}` | `--input path/to/file.txt` |
+| `input.from: file` | `{{input}}` | `--input path/to/file.txt` or `input.path` in YAML |
+| `--input-file <path>` | `{{input}}` | File read directly as UTF-8 by Node.js (overrides stdin/args/file) |
 | `--var topic=AI` | `{{topic}}` | Can coexist with any `from` |
 | `steps.X.output` | `{{steps.X.output}}` | Output of a preceding step (multi-step mode) |
 

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -71,6 +71,7 @@ Usage: yali run <command.yaml> [options]
 | オプション | 引数 | 説明 |
 |---|---|---|
 | `--input <value\|path>` | 文字列またはファイルパス | プライマリ入力変数を設定。`input.from` が `file` の場合はファイルパスとして解釈される |
+| `--input-file <path>` | ファイルパス | ファイルをNode.jsが直接UTF-8で読み込みプライマリ入力変数として使用。PowerShellのパイプエンコーディング問題を回避できる |
 | `--var <key=value>` | `キー=値` 形式 | 任意のテンプレート変数を設定。複数回指定可能 |
 | `--dry-run` | なし | LLMを呼び出さずにプロンプトのレンダリングのみ行う |
 | `--format <text\|json>` | `text` または `json` | `--dry-run` の出力フォーマット（デフォルト: `text`） |
@@ -79,11 +80,14 @@ Usage: yali run <command.yaml> [options]
 ### 基本的な使い方
 
 ```bash
-# YAMLコマンドを実行（stdin入力）
-echo "Hello, world" | yali run translate.yaml
-
-# --input で値を直接指定
+# --input で値を直接指定（推奨：パイプエンコーディング問題を回避）
 yali run translate.yaml --input "Hello, world"
+
+# ファイルをそのまま渡す（--input-file 推奨：文字化けしない）
+yali run summarize-then-translate.yaml --input-file ./report.txt
+
+# stdin パイプ（ASCII テキストのみ推奨）
+echo "Hello, world" | yali run translate.yaml
 
 # 複数の変数を注入
 yali run summarize.yaml --input "本文..." --var lang=Japanese --var style=formal
@@ -94,6 +98,12 @@ yali run translate.yaml --input "test" --dry-run
 # ドライランをJSONで出力
 yali run translate.yaml --input "test" --dry-run --format json
 ```
+
+> **Windowsでの注意事項**
+> PowerShellのデフォルトパイプエンコーディングはASCIIのため、日本語などのマルチバイト文字をパイプ経由で渡すと文字化けする場合があります。
+> - 文字列は `--input "テキスト"` で渡す（引数なので文字化けしない）
+> - ファイルは `--input-file ./file.txt` で渡す（Node.jsがUTF-8で直接読む）
+> - パイプを使う場合は先に `$OutputEncoding = [System.Text.Encoding]::UTF8` を設定する
 
 ---
 
@@ -272,8 +282,14 @@ input:
 ```
 
 ```bash
+# Windows推奨：--input でテキストを直接渡す（文字化けしない）
+yali run translate.yaml --input "翻訳するテキスト"
+
+# Unix/Linux/macOS：パイプでも動作
 echo "翻訳するテキスト" | yali run translate.yaml
-cat document.txt | yali run summarize.yaml
+
+# ファイルを渡す場合は --input-file 推奨（全プラットフォームで文字化けしない）
+yali run summarize.yaml --input-file document.txt
 ```
 
 #### from: args（直接値指定）
@@ -428,12 +444,15 @@ output:
 ```
 
 ```bash
-# jq でフィールドを抽出
+# Windows推奨：--input で直接テキストを渡す（文字化けしない）
+yali run analyze.yaml --input "素晴らしい製品です！" | jq '.sentiment'
+
+# Unix/Linux/macOS：パイプでも動作
 echo "素晴らしい製品です！" | yali run analyze.yaml | jq '.sentiment'
 
 # 複数ファイルをバッチ処理
 for f in reviews/*.txt; do
-  cat "$f" | yali run analyze.yaml | jq -c '{file: "'"$f"'", sentiment: .sentiment}'
+  yali run analyze.yaml --input-file "$f" | jq -c '{file: "'"$f"'", sentiment: .sentiment}'
 done
 ```
 
@@ -536,6 +555,10 @@ output:
 ```
 
 ```bash
+# Windows推奨：--input で直接渡す
+yali run translate.yaml --input "The quick brown fox jumps over the lazy dog."
+
+# Unix/Linux/macOS：パイプでも動作
 echo "The quick brown fox jumps over the lazy dog." | yali run translate.yaml
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -70,6 +70,7 @@ yali run <command.yaml> [options]
 | Option | Argument | Description |
 |---|---|---|
 | `--input <value\|path>` | string | Sets the primary input variable. Behavior depends on `input.from` in the YAML: with `from: args`, the value is used directly; with `from: file`, the value is treated as a file path to read. |
+| `--input-file <path>` | file path | Reads a file as UTF-8 directly in Node.js and uses the content as the primary input variable. Works regardless of `input.from`. Recommended on Windows to avoid PowerShell pipe encoding issues with non-ASCII text. |
 | `--var <key=value>` | `key=value` | Sets an arbitrary template variable. Repeatable — pass multiple `--var` flags for multiple variables. Takes the highest resolution priority (see [Input Resolution](#input-resolution)). |
 | `--dry-run` | — | Renders all prompts without calling the LLM API. Useful for inspecting expanded templates before running. |
 | `--format <text\|json>` | `text` or `json` | Controls the output format for `--dry-run`. Defaults to `text`. Has no effect without `--dry-run`. |
@@ -78,14 +79,14 @@ yali run <command.yaml> [options]
 ### Basic usage
 
 ```bash
-# Run a command file with piped stdin
-echo "Hello, world" | yali run translate.yaml
-
-# Run with explicit --input value
+# Run with explicit --input value (recommended: avoids pipe encoding issues)
 yali run translate.yaml --input "Hello, world"
 
-# Run with a file as input
-yali run summarize.yaml --input ./article.txt
+# Run with a file as input (--input-file reads directly as UTF-8, avoids encoding issues)
+yali run summarize.yaml --input-file ./article.txt
+
+# Run a command file with piped stdin (ASCII text only on Windows)
+echo "Hello, world" | yali run translate.yaml
 
 # Inject template variables
 yali run greet.yaml --var name=Alice --var lang=French
@@ -96,6 +97,8 @@ yali run pipeline.yaml --input "some text" --dry-run
 # Preview as JSON (machine-readable)
 yali run pipeline.yaml --input "some text" --dry-run --format json
 ```
+
+> **Windows note:** PowerShell's default pipe encoding is ASCII. Piping non-ASCII text (e.g. Japanese) via `echo "..." | yali run ...` or `Get-Content ... | yali run ...` will garble multibyte characters. Use `--input "text"` or `--input-file ./file.txt` instead.
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,11 +12,12 @@ function printUsage(stream: NodeJS.WriteStream = process.stdout): void {
       'Usage: yali run <command.yaml> [options]',
       '',
       'Options:',
-      '  --input <value|path>   Set the primary input variable, or file path when input.from is "file"',
-      '  --var <key=value>     Set an arbitrary template variable (repeatable)',
-      '  --dry-run             Render prompts without calling the LLM',
-      '  --format <text|json>  Output format for --dry-run (default: text)',
-      '  --help                Show this help message',
+      '  --input <value|path>        Set the primary input variable, or file path when input.from is "file"',
+      '  --input-file <path>         Read a file as the primary input variable (avoids PowerShell pipe encoding issues)',
+      '  --var <key=value>          Set an arbitrary template variable (repeatable)',
+      '  --dry-run                  Render prompts without calling the LLM',
+      '  --format <text|json>       Output format for --dry-run (default: text)',
+      '  --help                     Show this help message',
       '',
     ].join('\n'),
   );
@@ -27,6 +28,7 @@ export async function main(): Promise<void> {
     args: process.argv.slice(2),
     options: {
       input: { type: 'string' },
+      'input-file': { type: 'string' },
       var: { type: 'string', multiple: true },
       'dry-run': { type: 'boolean', default: false },
       format: { type: 'string', default: 'text' },
@@ -68,6 +70,7 @@ export async function main(): Promise<void> {
     variables = await resolveInput(command, {
       vars,
       inputArg: values['input'],
+      inputFileArg: values['input-file'],
       hasStdin,
     });
   } catch (e) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { parseArgs } from 'node:util';
 import { parseCommand } from './parser/index.js';
 import { orderSteps, renderStep } from './renderer/index.js';
@@ -5,8 +6,8 @@ import { execute } from './executor/index.js';
 import { resolveInput, InputResolverError } from './cli/input-resolver.js';
 import { formatDryRun } from './cli/dry-run-formatter.js';
 
-function printUsage(): void {
-  process.stderr.write(
+function printUsage(stream: NodeJS.WriteStream = process.stdout): void {
+  stream.write(
     [
       'Usage: yali run <command.yaml> [options]',
       '',
@@ -42,7 +43,7 @@ export async function main(): Promise<void> {
 
   // Expect: yali run <file.yaml>
   if (positionals[0] !== 'run' || !positionals[1]) {
-    printUsage();
+    printUsage(process.stderr);
     process.exit(1);
   }
 
@@ -104,9 +105,18 @@ export async function main(): Promise<void> {
 }
 
 import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
 
-// Only call main() when this file is the direct entry point (not when imported by tests)
-const isEntryPoint = process.argv[1] === fileURLToPath(import.meta.url);
+// Only call main() when this file is the direct entry point (not when imported by tests).
+// realpathSync resolves Windows Junction symlinks created by `npm link`, ensuring
+// process.argv[1] and import.meta.url compare against the same canonical path.
+const isEntryPoint = (() => {
+  try {
+    return realpathSync(process.argv[1]!) === fileURLToPath(import.meta.url);
+  } catch {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  }
+})();
 if (isEntryPoint) {
   main();
 }

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -87,10 +87,12 @@ describe('CLI Layer', () => {
     });
   });
 
-  it('exits 1 and prints usage when subcommand is missing', async () => {
+  it('exits 1 and prints usage to stderr when subcommand is missing', async () => {
     process.argv = ['node', 'cli.js'];
     await expect(main()).rejects.toThrow('process.exit(1)');
     expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrOutput).toContain('Usage: yali run');
   });
 
   it('exits 1 and prints usage when yaml file is missing', async () => {

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -151,8 +151,8 @@ describe('CLI Layer', () => {
     process.argv = ['node', 'cli.js', '--help'];
     await expect(main()).rejects.toThrow('process.exit(0)');
     expect(exitSpy).toHaveBeenCalledWith(0);
-    const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
-    expect(stderrOutput).toContain('Usage: yali run');
+    const stdoutOutput = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stdoutOutput).toContain('Usage: yali run');
   });
 
   it('exits 1 and prints to stderr when parseCommand throws', async () => {

--- a/src/cli/input-resolver.test.ts
+++ b/src/cli/input-resolver.test.ts
@@ -71,7 +71,7 @@ describe('resolveInput — Input Resolution Order', () => {
     expect(result['input']).toBe('from-stdin');
   });
 
-  it('from=stdin: --input arg is ignored (stdin source uses piped stdin)', async () => {
+  it('from=stdin: --input arg is ignored when stdin IS piped (stdin takes priority)', async () => {
     const command = makeCommand({ from: 'stdin' });
     const result = await resolveInput(command, {
       vars: [],
@@ -80,6 +80,16 @@ describe('resolveInput — Input Resolution Order', () => {
       stdin: makeReadable('from-stdin'),
     });
     expect(result['input']).toBe('from-stdin');
+  });
+
+  it('from=stdin: --input used as fallback when no stdin pipe is available', async () => {
+    const command = makeCommand({ from: 'stdin' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputArg: 'fallback-value',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('fallback-value');
   });
 
   it('from=args: --input value is used directly', async () => {
@@ -180,6 +190,13 @@ describe('resolveInput — Input Resolution Order', () => {
     const command = makeCommand({ from: 'file', path: './missing.txt' });
     await expect(
       resolveInput(command, { vars: [], hasStdin: false }),
+    ).rejects.toThrow(InputResolverError);
+  });
+
+  it('throws InputResolverError when from=file with no --input and no YAML path', async () => {
+    const command = makeCommand({ from: 'file' }); // no path in YAML
+    await expect(
+      resolveInput(command, { vars: [], hasStdin: false }), // no --input either
     ).rejects.toThrow(InputResolverError);
   });
 

--- a/src/cli/input-resolver.test.ts
+++ b/src/cli/input-resolver.test.ts
@@ -200,6 +200,53 @@ describe('resolveInput — Input Resolution Order', () => {
     ).rejects.toThrow(InputResolverError);
   });
 
+  // ── Priority 1.5: --input-file ────────────────────────────────────────────
+
+  it('Priority 1.5: --input-file reads file and sets the input variable', async () => {
+    mockedReadFileSync.mockReturnValue('file content via --input-file');
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputFileArg: './doc.txt',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('file content via --input-file');
+    expect(mockedReadFileSync).toHaveBeenCalledWith('./doc.txt', 'utf-8');
+  });
+
+  it('Priority 1.5: --input-file overrides stdin when both are provided', async () => {
+    mockedReadFileSync.mockReturnValue('from-file');
+    const command = makeCommand({ from: 'stdin' });
+    const result = await resolveInput(command, {
+      vars: [],
+      inputFileArg: './doc.txt',
+      hasStdin: true,
+      stdin: makeReadable('from-stdin'),
+    });
+    expect(result['input']).toBe('from-file');
+  });
+
+  it('Priority 1.5: --var overrides --input-file (--var has higher priority)', async () => {
+    mockedReadFileSync.mockReturnValue('from-file');
+    const command = makeCommand({ from: 'args' });
+    const result = await resolveInput(command, {
+      vars: ['input=from-var'],
+      inputFileArg: './doc.txt',
+      hasStdin: false,
+    });
+    expect(result['input']).toBe('from-var');
+  });
+
+  it('throws InputResolverError when --input-file path does not exist', async () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+    const command = makeCommand({ from: 'args' });
+    await expect(
+      resolveInput(command, { vars: [], inputFileArg: './missing.txt', hasStdin: false }),
+    ).rejects.toThrow(InputResolverError);
+  });
+
   it('returns empty object when no sources apply', async () => {
     const command = makeCommand({ from: 'args' });
     const result = await resolveInput(command, { vars: [], hasStdin: false });

--- a/src/cli/input-resolver.ts
+++ b/src/cli/input-resolver.ts
@@ -48,6 +48,12 @@ export async function resolveInput(
      * - When input.from === 'stdin': ignored (stdin is used instead).
      */
     inputArg?: string;
+    /**
+     * Value from --input-file flag. Reads the specified file as UTF-8 and uses the content
+     * as the primary input variable value — regardless of input.from setting.
+     * This bypasses PowerShell pipe encoding issues for Japanese/CJK text on Windows.
+     */
+    inputFileArg?: string;
     /** Whether stdin is available (i.e. !process.stdin.isTTY). */
     hasStdin: boolean;
     /** Injectable stdin stream for testing. Defaults to process.stdin. */
@@ -91,6 +97,18 @@ export async function resolveInput(
   } else if (input_spec.from === 'args') {
     if (opts.inputArg !== undefined) {
       variables[input_spec.var] = opts.inputArg;
+    }
+  }
+
+  // Priority 1.5 — --input-file flag: read file directly in Node.js (UTF-8), bypassing pipe encoding.
+  // Applied after primary source so it overrides stdin/args, but before --var so --var can still override.
+  if (opts.inputFileArg !== undefined) {
+    try {
+      variables[input_spec.var] = readFileSync(opts.inputFileArg, 'utf-8');
+    } catch (e) {
+      throw new InputResolverError(
+        `Cannot read --input-file: ${opts.inputFileArg} — ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 

--- a/src/cli/input-resolver.ts
+++ b/src/cli/input-resolver.ts
@@ -74,11 +74,19 @@ export async function resolveInput(
           `Cannot read input file: ${filePath} — ${e instanceof Error ? e.message : String(e)}`,
         );
       }
+    } else {
+      throw new InputResolverError(
+        'input.from is "file" but no file path was provided. Use --input <path> or set input.path in the YAML.',
+      );
     }
   } else if (input_spec.from === 'stdin') {
     if (opts.hasStdin) {
       const stream = opts.stdin ?? process.stdin;
       variables[input_spec.var] = await readStream(stream);
+    } else if (opts.inputArg !== undefined) {
+      // Convenience fallback: when no stdin pipe but --input is provided,
+      // use --input directly. Useful for dry-run and ad-hoc testing without piping.
+      variables[input_spec.var] = opts.inputArg;
     }
   } else if (input_spec.from === 'args') {
     if (opts.inputArg !== undefined) {

--- a/src/executor/index.test.ts
+++ b/src/executor/index.test.ts
@@ -432,4 +432,62 @@ describe('execute()', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('path');
   });
+
+  // ---------------------------------------------------------------------------
+  // Multi-step streaming: only the final step streams to stdout
+  // ---------------------------------------------------------------------------
+  it('only the final step uses streaming; intermediate steps are buffered', async () => {
+    // Step 1: buffered (non-streaming) response
+    // Step 2: streaming response (final step)
+    mockCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'intermediate output' } }] })
+      .mockImplementationOnce(async () => {
+        async function* gen() {
+          yield { choices: [{ delta: { content: 'final ' } }] };
+          yield { choices: [{ delta: { content: 'output' } }] };
+        }
+        return gen();
+      });
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { execute } = await import('./index.js');
+    const command: ValidatedCommand = {
+      steps: [
+        {
+          id: 'step1',
+          prompt: 'Summarize: {{input}}',
+          model: { name: 'gpt-4o-mini' },
+          depends_on: [],
+        },
+        {
+          id: 'step2',
+          prompt: 'Translate: {{steps.step1.output}}',
+          model: { name: 'gpt-4o' },
+          depends_on: ['step1'],
+        },
+      ],
+      input_spec: { from: 'args', var: 'input' },
+      output_spec: { format: 'text', target: 'stdout' },
+    };
+
+    const result = await execute(command, { input: 'some long text' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('final output');
+
+    // First call must be non-streaming (stream: false or absent)
+    const firstCallArgs = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(firstCallArgs?.['stream']).toBeFalsy();
+
+    // Second call (final step) must be streaming
+    const secondCallArgs = mockCreate.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(secondCallArgs?.['stream']).toBe(true);
+
+    // stdout should receive the streamed chunks from the final step
+    expect(writeSpy).toHaveBeenCalledWith('final ');
+    expect(writeSpy).toHaveBeenCalledWith('output');
+
+    writeSpy.mockRestore();
+  });
 });

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -200,12 +200,16 @@ export async function execute(
     const orderedSteps = orderSteps(command);
     let lastOutput = '';
 
-    for (const step of orderedSteps) {
+    for (let i = 0; i < orderedSteps.length; i++) {
+      const step = orderedSteps[i]!;
       const rendered = renderStep(step, vars);
       const { name: modelName, temperature, max_tokens } = rendered.model;
 
+      // Only stream the final step to stdout; intermediate steps must be buffered
+      // so their output doesn't appear in the terminal before the pipeline is done.
+      const isFinalStep = i === orderedSteps.length - 1;
       let rawOutput: string;
-      if (useStreaming) {
+      if (useStreaming && isFinalStep) {
         rawOutput = await callLLMStreaming(client, rendered.prompt, modelName, temperature, max_tokens);
       } else {
         rawOutput = await callLLM(client, rendered.prompt, modelName, temperature, max_tokens);

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -125,6 +125,15 @@ describe('ValidatedCommandSchema — validation errors', () => {
     expect(() => ValidatedCommandSchema.parse({ model: 'gpt-4o' })).toThrow();
   });
 
+  it('throws when both prompt and steps are specified', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({
+        prompt: 'Hello',
+        steps: [{ id: 's1', prompt: 'World', model: 'gpt-4o' }],
+      }),
+    ).toThrow(/Cannot specify both/);
+  });
+
   it('throws when input.from is an invalid enum value', () => {
     expect(() =>
       ValidatedCommandSchema.parse({
@@ -143,6 +152,16 @@ describe('ValidatedCommandSchema — validation errors', () => {
         output: { format: 'xml', target: 'stdout' },
       }),
     ).toThrow();
+  });
+
+  it('throws when output.target is "file" but output.path is missing', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({
+        prompt: 'Hi',
+        model: 'gpt-4o',
+        output: { format: 'text', target: 'file' },
+      }),
+    ).toThrow(/output\.path is required/);
   });
 
   it('throws when a step is missing required id field', () => {
@@ -185,6 +204,10 @@ describe('parseCommand — file I/O', () => {
 
   it('throws ParseError when file does not exist', () => {
     expect(() => parseCommand('/nonexistent/path/cmd.yaml')).toThrowError(ParseError);
+  });
+
+  it('error message says "Cannot find YAML file" when file does not exist', () => {
+    expect(() => parseCommand('/nonexistent/path/cmd.yaml')).toThrow('Cannot find YAML file');
   });
 
   it('throws ParseError on YAML syntax error', () => {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -9,7 +9,7 @@ export function parseCommand(filePath: string): ValidatedCommand {
   try {
     raw = readFileSync(filePath, 'utf-8');
   } catch (e) {
-    throw new ParseError(`Cannot read file: ${filePath}`, e);
+    throw new ParseError(`Cannot find YAML file: ${filePath}`, e);
   }
 
   let yaml: unknown;

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -28,7 +28,10 @@ const OutputSpecSchema = z.object({
   format: z.enum(['text', 'markdown', 'json']),
   target: z.enum(['stdout', 'file']),
   path: z.string().optional(),
-});
+}).refine(
+  (val) => val.target !== 'file' || val.path !== undefined,
+  { message: 'output.path is required when output.target is "file"' },
+);
 
 const ToolSpecSchema = z.object({
   type: z.string(),
@@ -60,7 +63,10 @@ export const ValidatedCommandSchema: z.ZodType<ValidatedCommand, z.ZodTypeDef, u
 
     // Resolve steps
     let steps: ValidatedCommand['steps'];
-    if (data.steps !== undefined) {
+    if (data.steps !== undefined && data.prompt !== undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Cannot specify both "prompt" and "steps" in the same YAML file' });
+      return z.NEVER;
+    } else if (data.steps !== undefined) {
       const stepsResult = z.array(StepSchema).safeParse(data.steps);
       if (!stepsResult.success) {
         stepsResult.error.issues.forEach((issue) => ctx.addIssue(issue));

--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -110,7 +110,7 @@ describe('renderSteps — undefined variable errors', () => {
 
   it('RenderError message names the missing variable', () => {
     const cmd = makeCommand();
-    expect(() => renderSteps(cmd, {})).toThrowError(/input/);
+    expect(() => renderSteps(cmd, {})).toThrowError('Variable "input" is not defined');
   });
 
   it('RenderError has correct name property', () => {

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -19,7 +19,7 @@ function expandTemplate(template: string, variables: Record<string, string>): st
   return template.replace(TEMPLATE_PATTERN, (_match, key: string) => {
     const trimmedKey = key.trim();
     if (!(trimmedKey in variables)) {
-      throw new RenderError(`Undefined variable: "{{${trimmedKey}}}" has no value in the variable map`);
+      throw new RenderError(`Variable "${trimmedKey}" is not defined`);
     }
     return variables[trimmedKey];
   });


### PR DESCRIPTION
## 概要

user-guide.ja.md に沿って全機能を実際に動作確認し、発見したバグを修正するとともに、Windows PowerShell のエンコーディング問題に対応しました。

## 変更内容

### バグ修正（10件）
| # | 概要 | 該当ファイル |
|---|---|---|
| BUG-1 | マルチステップで全ステップがストリーミング出力されていた → 最終ステップのみストリーム | \src/executor/index.ts\ |
| BUG-2 | \prompt\ と \steps\ を両方指定した場合にサイレントで片方が無視された → バリデーションエラーに | \src/parser/schema.ts\ |
| BUG-3 | \--help\ が stderr に出力されていた → stdout に変更 | \src/cli.ts\ |
| BUG-4 | YAMLファイルが見つからない時のエラーメッセージが仕様と異なっていた | \src/parser/index.ts\ |
| BUG-5 | RenderError のメッセージ形式が仕様と異なっていた | \src/renderer/index.ts\ |
| BUG-6 | shebang がなく Windows で WScript.exe が cli.js を実行していた | \src/cli.ts\ |
| BUG-7 | \
pm link\ の Windows Junction で \isEntryPoint\ 判定が失敗し main() が未起動 | \src/cli.ts\ |
| BUG-8 | \rom:stdin\ + パイプなし時に \--input\ フォールバックがなかった | \src/cli/input-resolver.ts\ |
| BUG-9 | \output.target: file\ でも \output.path\ 未指定がパース時に検出されなかった | \src/parser/schema.ts\ |
| BUG-10 | \rom:file\ でパス未指定時にサイレントスキップされていた | \src/cli/input-resolver.ts\ |

### 新機能
- **\--input-file <path>\** フラグを追加  
  PowerShell のデフォルトパイプエンコーディング（ASCII）による日本語文字化け問題を回避するため、Node.js がファイルを直接 UTF-8 で読み込む

### ドキュメント更新
- \docs/user-guide.ja.md\ / \docs/user-guide.md\ に \--input-file\ を追加
- Windows での推奨パターンと注意事項を追記
- \cho ... |\ パイプ例を \--input\ / \--input-file\ 推奨に変更

## テスト
- 109 tests passed (0 failed)
- 実際の LLM 呼び出しによる E2E スモークテストも完了

Closes #smoke-test