### PR TITLE
feat: プロバイダーアダプター設計 — Executor 層リファクタリング & 未設定 API キーの明示的エラー表示

### DIFF
--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -226,6 +226,8 @@ cat input.txt | yali run translate.yaml | jq '.result'
 ## Appendix: Internal Type Definitions (Pseudocode)
 
 ```
+ProviderName = 'openai' | 'anthropic' | 'google' | 'ollama'
+
 ValidatedCommand {
   name?:        string
   version?:     string
@@ -244,6 +246,7 @@ Step {
 
 ModelSpec {
   name:         string
+  provider?:    ProviderName    # defaults to 'openai' when omitted; resolved by the Parser
   temperature?: float
   max_tokens?:  int
 }

--- a/src/executor/adapters/openai.test.ts
+++ b/src/executor/adapters/openai.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('openai', () => {
+  const mockCreate = vi.fn();
+
+  class FakeAPIError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'APIError';
+      this.status = status;
+    }
+  }
+
+  const OpenAI = vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: mockCreate,
+      },
+    },
+  }));
+
+  (OpenAI as unknown as Record<string, unknown>)['APIError'] = FakeAPIError;
+
+  return { default: OpenAI, __mockCreate: mockCreate };
+});
+
+describe('OpenAIAdapter', () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+  let OpenAIAdapter: new (apiKey: string) => import('./openai.js').OpenAIAdapter;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const openaiModule = (await import('openai')) as unknown as {
+      __mockCreate: ReturnType<typeof vi.fn>;
+    };
+    mockCreate = openaiModule.__mockCreate;
+    ({ OpenAIAdapter } = await import('./openai.js'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  function mockNonStreaming(content: string) {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content } }],
+    });
+  }
+
+  function mockStreaming(chunks: string[]) {
+    async function* gen() {
+      for (const chunk of chunks) {
+        yield { choices: [{ delta: { content: chunk } }] };
+      }
+    }
+    mockCreate.mockResolvedValue(gen());
+  }
+
+  // call() — 正常系
+  it('call() returns the response text', async () => {
+    mockNonStreaming('Hello, world!');
+    const adapter = new OpenAIAdapter('test-key');
+    const result = await adapter.call('Say hello', { name: 'gpt-4o-mini' });
+    expect(result).toBe('Hello, world!');
+  });
+
+  // call() — temperature, max_tokens が API に渡される
+  it('call() forwards temperature and max_tokens to the API', async () => {
+    mockNonStreaming('result');
+    const adapter = new OpenAIAdapter('test-key');
+    await adapter.call('prompt', { name: 'gpt-4o', temperature: 0.7, max_tokens: 256 });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.7, max_tokens: 256 }),
+    );
+  });
+
+  // call() — 429 でリトライし成功する
+  it('call() retries on 429 and succeeds', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate
+      .mockRejectedValueOnce(new APIError('rate limit', 429))
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'retry success' } }] });
+
+    const adapter = new OpenAIAdapter('test-key');
+    const promise = adapter.call('prompt', { name: 'gpt-4o-mini' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('retry success');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // call() — 400 (non-retryable) はリトライしない
+  it('call() does not retry on 400 (non-retryable)', async () => {
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('bad request', 400));
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(adapter.call('prompt', { name: 'gpt-4o-mini' })).rejects.toBeInstanceOf(
+      ExecutorError,
+    );
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — MAX_RETRIES 回失敗後 ExecutorError をスロー
+  it('call() throws ExecutorError after exhausting all retries', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    // Attach .catch() immediately to avoid unhandled rejection warning
+    let caughtError: unknown;
+    const settled = adapter.call('prompt', { name: 'gpt-4o-mini' }).catch((e) => {
+      caughtError = e;
+    });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  // call() — ECONNRESET でリトライし成功する
+  it('call() retries on ECONNRESET and succeeds', async () => {
+    vi.useFakeTimers();
+    const networkError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    mockCreate
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'network retry ok' } }] });
+
+    const adapter = new OpenAIAdapter('test-key');
+    const promise = adapter.call('prompt', { name: 'gpt-4o-mini' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('network retry ok');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // callStreaming() — chunks が onChunk コールバックで返される
+  it('callStreaming() invokes onChunk for each chunk', async () => {
+    mockStreaming(['Hello ', 'world!']);
+    const adapter = new OpenAIAdapter('test-key');
+    const chunks: string[] = [];
+    await adapter.callStreaming('prompt', { name: 'gpt-4o-mini' }, (c) => chunks.push(c));
+    expect(chunks).toEqual(['Hello ', 'world!']);
+  });
+
+  // callStreaming() — 累積テキストを返す
+  it('callStreaming() returns the accumulated full text', async () => {
+    mockStreaming(['Hello ', 'world!']);
+    const adapter = new OpenAIAdapter('test-key');
+    const result = await adapter.callStreaming('prompt', { name: 'gpt-4o-mini' }, () => {});
+    expect(result).toBe('Hello world!');
+  });
+});

--- a/src/executor/adapters/openai.ts
+++ b/src/executor/adapters/openai.ts
@@ -1,0 +1,112 @@
+import OpenAI from 'openai';
+import type { ModelSpec } from '../../types/index.js';
+import { ExecutorError } from '../errors.js';
+import type { LLMAdapter } from './types.js';
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof OpenAI.APIError) {
+    return RETRYABLE_STATUS_CODES.has(error.status);
+  }
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ENOTFOUND';
+  }
+  return false;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class OpenAIAdapter implements LLMAdapter {
+  private readonly client: OpenAI;
+
+  constructor(apiKey: string) {
+    this.client = new OpenAI({ apiKey });
+  }
+
+  async call(prompt: string, model: ModelSpec): Promise<string> {
+    const { name: modelName, temperature, max_tokens } = model;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
+
+      try {
+        const response = await this.client.chat.completions.create({
+          model: modelName,
+          messages: [{ role: 'user', content: prompt }],
+          ...(temperature !== undefined && { temperature }),
+          ...(max_tokens !== undefined && { max_tokens }),
+        });
+
+        return response.choices[0]?.message?.content ?? '';
+      } catch (error) {
+        lastError = error;
+        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+          break;
+        }
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new ExecutorError(
+      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      lastError,
+    );
+  }
+
+  async callStreaming(
+    prompt: string,
+    model: ModelSpec,
+    onChunk: (chunk: string) => void,
+  ): Promise<string> {
+    const { name: modelName, temperature, max_tokens } = model;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
+
+      try {
+        const stream = await this.client.chat.completions.create({
+          model: modelName,
+          messages: [{ role: 'user', content: prompt }],
+          stream: true,
+          ...(temperature !== undefined && { temperature }),
+          ...(max_tokens !== undefined && { max_tokens }),
+        });
+
+        let fullText = '';
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content ?? '';
+          if (delta) {
+            onChunk(delta);
+            fullText += delta;
+          }
+        }
+        return fullText;
+      } catch (error) {
+        lastError = error;
+        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+          break;
+        }
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new ExecutorError(
+      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      lastError,
+    );
+  }
+}

--- a/src/executor/adapters/types.test.ts
+++ b/src/executor/adapters/types.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ExecutorError } from '../errors.js';
+
+// Mock OpenAIAdapter so createAdapter doesn't need a real API key
+vi.mock('./openai.js', () => ({
+  OpenAIAdapter: class MockOpenAIAdapter {
+    constructor(public readonly apiKey: string) {}
+    call = vi.fn();
+    callStreaming = vi.fn();
+  },
+}));
+
+describe('createAdapter()', () => {
+  it("returns an adapter with call() and callStreaming() for 'openai'", async () => {
+    const { createAdapter } = await import('./types.js');
+    const adapter = createAdapter('openai', 'test-key');
+    expect(typeof adapter.call).toBe('function');
+    expect(typeof adapter.callStreaming).toBe('function');
+  });
+
+  it("throws ExecutorError for 'anthropic' (not yet supported)", async () => {
+    const { createAdapter } = await import('./types.js');
+    expect(() => createAdapter('anthropic', 'key')).toThrow(ExecutorError);
+    expect(() => createAdapter('anthropic', 'key')).toThrow(/not yet supported/);
+  });
+
+  it("throws ExecutorError for 'google' (not yet supported)", async () => {
+    const { createAdapter } = await import('./types.js');
+    expect(() => createAdapter('google', 'key')).toThrow(ExecutorError);
+    expect(() => createAdapter('google', 'key')).toThrow(/not yet supported/);
+  });
+
+  it("throws ExecutorError for 'ollama' (not yet supported)", async () => {
+    const { createAdapter } = await import('./types.js');
+    expect(() => createAdapter('ollama', 'key')).toThrow(ExecutorError);
+    expect(() => createAdapter('ollama', 'key')).toThrow(/not yet supported/);
+  });
+
+  it('error message for unsupported provider names the provider', async () => {
+    const { createAdapter } = await import('./types.js');
+    expect(() => createAdapter('anthropic', 'key')).toThrow(/anthropic/);
+    expect(() => createAdapter('google', 'key')).toThrow(/google/);
+  });
+});

--- a/src/executor/adapters/types.ts
+++ b/src/executor/adapters/types.ts
@@ -1,0 +1,43 @@
+import type { ModelSpec, ProviderName } from '../../types/index.js';
+import { ExecutorError } from '../errors.js';
+import { OpenAIAdapter } from './openai.js';
+
+/**
+ * Common interface for all LLM provider adapters.
+ * Only the Executor layer may use this interface.
+ */
+export interface LLMAdapter {
+  /** Calls the LLM API and returns the full response text. */
+  call(prompt: string, model: ModelSpec): Promise<string>;
+  /**
+   * Calls the LLM API with streaming.
+   * Invokes onChunk for each received text chunk.
+   * Returns the accumulated full response text.
+   */
+  callStreaming(
+    prompt: string,
+    model: ModelSpec,
+    onChunk: (chunk: string) => void,
+  ): Promise<string>;
+}
+
+/**
+ * Creates an LLMAdapter for the given provider.
+ * Throws ExecutorError for unsupported providers.
+ */
+export function createAdapter(provider: ProviderName, apiKey: string): LLMAdapter {
+  switch (provider) {
+    case 'openai':
+      return new OpenAIAdapter(apiKey);
+    case 'anthropic':
+    case 'google':
+    case 'ollama':
+      throw new ExecutorError(
+        `Provider '${provider}' is not yet supported. Only 'openai' is currently available.`,
+      );
+    default: {
+      const _exhaustive: never = provider;
+      throw new ExecutorError(`Unknown provider: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/src/executor/api-key-resolver.test.ts
+++ b/src/executor/api-key-resolver.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveApiKey } from './api-key-resolver.js';
+import { ExecutorError } from './errors.js';
+
+const ALL_ENV_VARS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_API_KEY',
+  'OLLAMA_API_KEY',
+] as const;
+
+afterEach(() => {
+  for (const key of ALL_ENV_VARS) {
+    delete process.env[key];
+  }
+});
+
+describe('resolveApiKey()', () => {
+  // ---------------------------------------------------------------------------
+  // openai
+  // ---------------------------------------------------------------------------
+  it('returns the key when OPENAI_API_KEY is set', () => {
+    process.env['OPENAI_API_KEY'] = 'sk-test-openai';
+    expect(resolveApiKey('openai')).toBe('sk-test-openai');
+  });
+
+  it('throws ExecutorError when OPENAI_API_KEY is not set', () => {
+    expect(() => resolveApiKey('openai')).toThrow(ExecutorError);
+  });
+
+  it('error message mentions the env var name for openai', () => {
+    expect(() => resolveApiKey('openai')).toThrow(/OPENAI_API_KEY/);
+  });
+
+  it('error message includes yali config set guidance for openai', () => {
+    expect(() => resolveApiKey('openai')).toThrow(/yali config set openai\.api_key/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Provider → env var mapping
+  // ---------------------------------------------------------------------------
+  it('maps anthropic to ANTHROPIC_API_KEY', () => {
+    process.env['ANTHROPIC_API_KEY'] = 'ant-key';
+    expect(resolveApiKey('anthropic')).toBe('ant-key');
+  });
+
+  it('maps google to GOOGLE_API_KEY', () => {
+    process.env['GOOGLE_API_KEY'] = 'goog-key';
+    expect(resolveApiKey('google')).toBe('goog-key');
+  });
+
+  it('maps ollama to OLLAMA_API_KEY', () => {
+    process.env['OLLAMA_API_KEY'] = 'ollama-key';
+    expect(resolveApiKey('ollama')).toBe('ollama-key');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error messages for other providers
+  // ---------------------------------------------------------------------------
+  it('throws when anthropic key is missing with correct guidance', () => {
+    expect(() => resolveApiKey('anthropic')).toThrow(/yali config set anthropic\.api_key/);
+  });
+
+  it('error message for anthropic mentions ANTHROPIC_API_KEY', () => {
+    expect(() => resolveApiKey('anthropic')).toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it('error message includes capitalised provider label', () => {
+    // "OpenAI API key is not configured"
+    expect(() => resolveApiKey('openai')).toThrow(/OpenAI/);
+    // "Anthropic API key is not configured"
+    expect(() => resolveApiKey('anthropic')).toThrow(/Anthropic/);
+  });
+});

--- a/src/executor/api-key-resolver.ts
+++ b/src/executor/api-key-resolver.ts
@@ -9,6 +9,14 @@ const ENV_VAR_MAP: Record<ProviderName, string> = {
   ollama: 'OLLAMA_API_KEY',
 };
 
+/** Human-readable display names for each provider. */
+const PROVIDER_LABELS: Record<ProviderName, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  google: 'Google',
+  ollama: 'Ollama',
+};
+
 /**
  * Resolves the API key for the given provider.
  *
@@ -25,7 +33,7 @@ export function resolveApiKey(provider: ProviderName): string {
     return apiKey;
   }
 
-  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const providerLabel = PROVIDER_LABELS[provider];
   throw new ExecutorError(
     `${providerLabel} API key is not configured.\n` +
       `Set the ${envVar} environment variable, or run:\n` +

--- a/src/executor/api-key-resolver.ts
+++ b/src/executor/api-key-resolver.ts
@@ -1,0 +1,34 @@
+import type { ProviderName } from '../types/index.js';
+import { ExecutorError } from './errors.js';
+
+/** Maps provider names to their environment variable names. */
+const ENV_VAR_MAP: Record<ProviderName, string> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_API_KEY',
+  ollama: 'OLLAMA_API_KEY',
+};
+
+/**
+ * Resolves the API key for the given provider.
+ *
+ * Resolution order:
+ *   1. Environment variable (backward compatible)
+ *   2. (Future) ~/.config/yali/config.yaml — to be implemented with yali config issue
+ *
+ * Throws ExecutorError with user-friendly guidance if the key is not configured.
+ */
+export function resolveApiKey(provider: ProviderName): string {
+  const envVar = ENV_VAR_MAP[provider];
+  const apiKey = process.env[envVar];
+  if (apiKey) {
+    return apiKey;
+  }
+
+  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  throw new ExecutorError(
+    `${providerLabel} API key is not configured.\n` +
+      `Set the ${envVar} environment variable, or run:\n` +
+      `  yali config set ${provider}.api_key <YOUR_API_KEY>`,
+  );
+}

--- a/src/executor/index.test.ts
+++ b/src/executor/index.test.ts
@@ -94,7 +94,7 @@ describe('execute()', () => {
     const { execute } = await import('./index.js');
     const result = await execute(makeCommand(), { input: 'world' });
     expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('OPENAI_API_KEY');
+    expect(result.output).toContain('yali config set openai.api_key');
   });
 
   // ---------------------------------------------------------------------------

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,130 +1,9 @@
 import { writeFile } from 'node:fs/promises';
-import OpenAI from 'openai';
-import type { ValidatedCommand, ExecutionResult } from '../types/index.js';
+import type { ValidatedCommand, ExecutionResult, ProviderName } from '../types/index.js';
 import { orderSteps, renderStep } from '../renderer/index.js';
 import { ExecutorError } from './errors.js';
-
-// Retryable HTTP status codes
-const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 1000;
-
-function createClient(): OpenAI {
-  const apiKey = process.env['OPENAI_API_KEY'];
-  if (!apiKey) {
-    throw new ExecutorError('OPENAI_API_KEY environment variable is not set');
-  }
-  return new OpenAI({ apiKey });
-}
-
-function isRetryable(error: unknown): boolean {
-  if (error instanceof OpenAI.APIError) {
-    return RETRYABLE_STATUS_CODES.has(error.status);
-  }
-  // Network errors (no status code) are retryable
-  if (error instanceof Error && 'code' in error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ENOTFOUND';
-  }
-  return false;
-}
-
-async function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Calls the LLM API with exponential-backoff retry.
- * Returns the full response text.
- */
-async function callLLM(
-  client: OpenAI,
-  prompt: string,
-  modelName: string,
-  temperature?: number,
-  maxTokens?: number,
-): Promise<string> {
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    if (attempt > 0) {
-      await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
-    }
-
-    try {
-      const response = await client.chat.completions.create({
-        model: modelName,
-        messages: [{ role: 'user', content: prompt }],
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-      });
-
-      return response.choices[0]?.message?.content ?? '';
-    } catch (error) {
-      lastError = error;
-      if (!isRetryable(error) || attempt === MAX_RETRIES) {
-        break;
-      }
-    }
-  }
-
-  const message =
-    lastError instanceof Error ? lastError.message : String(lastError);
-  throw new ExecutorError(`LLM API call failed after ${MAX_RETRIES} retries: ${message}`, lastError);
-}
-
-/**
- * Calls the LLM API with streaming and writes chunks to stdout in real-time.
- * Returns the accumulated full response text.
- */
-async function callLLMStreaming(
-  client: OpenAI,
-  prompt: string,
-  modelName: string,
-  temperature?: number,
-  maxTokens?: number,
-): Promise<string> {
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    if (attempt > 0) {
-      await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
-    }
-
-    try {
-      const stream = await client.chat.completions.create({
-        model: modelName,
-        messages: [{ role: 'user', content: prompt }],
-        stream: true,
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-      });
-
-      let fullText = '';
-      for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta?.content ?? '';
-        if (delta) {
-          process.stdout.write(delta);
-          fullText += delta;
-        }
-      }
-      // Ensure trailing newline on stdout
-      if (fullText && !fullText.endsWith('\n')) {
-        process.stdout.write('\n');
-      }
-      return fullText;
-    } catch (error) {
-      lastError = error;
-      if (!isRetryable(error) || attempt === MAX_RETRIES) {
-        break;
-      }
-    }
-  }
-
-  const message =
-    lastError instanceof Error ? lastError.message : String(lastError);
-  throw new ExecutorError(`LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`, lastError);
-}
+import { resolveApiKey } from './api-key-resolver.js';
+import { createAdapter } from './adapters/types.js';
 
 /**
  * Formats the LLM output according to the requested format.
@@ -164,7 +43,7 @@ async function writeOutput(
     }
     await writeFile(path, content, 'utf-8');
   }
-  // stdout streaming is handled in callLLMStreaming; buffered stdout written by caller
+  // stdout streaming is handled by the adapter's onChunk callback; buffered stdout written by caller
 }
 
 /**
@@ -180,21 +59,12 @@ export async function execute(
   command: ValidatedCommand,
   variables: Record<string, string>,
 ): Promise<ExecutionResult> {
-  let client: OpenAI;
-  try {
-    client = createClient();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { exitCode: 1, output: message };
-  }
-
   const { output_spec } = command;
-  // Stream raw chunks to stdout only when target is stdout AND format doesn't require
-  // post-processing. json must be buffered first so formatOutput() can parse the full text.
   const useStreaming = output_spec.target === 'stdout' && output_spec.format !== 'json';
 
-  // Mutable copy so we can accumulate step outputs
   const vars: Record<string, string> = { ...variables };
+  // Cache adapters by provider to avoid re-creating clients
+  const adapterCache = new Map<ProviderName, ReturnType<typeof createAdapter>>();
 
   try {
     const orderedSteps = orderSteps(command);
@@ -203,19 +73,38 @@ export async function execute(
     for (let i = 0; i < orderedSteps.length; i++) {
       const step = orderedSteps[i]!;
       const rendered = renderStep(step, vars);
-      const { name: modelName, temperature, max_tokens } = rendered.model;
+      const { provider = 'openai', temperature, max_tokens } = rendered.model;
 
-      // Only stream the final step to stdout; intermediate steps must be buffered
-      // so their output doesn't appear in the terminal before the pipeline is done.
+      // Resolve adapter (with cache)
+      let adapter = adapterCache.get(provider);
+      if (!adapter) {
+        let apiKey: string;
+        try {
+          apiKey = resolveApiKey(provider);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { exitCode: 1, output: message };
+        }
+        adapter = createAdapter(provider, apiKey);
+        adapterCache.set(provider, adapter);
+      }
+
       const isFinalStep = i === orderedSteps.length - 1;
       let rawOutput: string;
       if (useStreaming && isFinalStep) {
-        rawOutput = await callLLMStreaming(client, rendered.prompt, modelName, temperature, max_tokens);
+        rawOutput = await adapter.callStreaming(
+          rendered.prompt,
+          rendered.model,
+          (chunk) => process.stdout.write(chunk),
+        );
+        // Ensure trailing newline on stdout
+        if (rawOutput && !rawOutput.endsWith('\n')) {
+          process.stdout.write('\n');
+        }
       } else {
-        rawOutput = await callLLM(client, rendered.prompt, modelName, temperature, max_tokens);
+        rawOutput = await adapter.call(rendered.prompt, rendered.model);
       }
 
-      // Accumulate for inter-step references
       vars[`steps.${step.id}.output`] = rawOutput;
       lastOutput = rawOutput;
     }
@@ -225,7 +114,6 @@ export async function execute(
     if (output_spec.target === 'file') {
       await writeOutput(formatted, output_spec.target, output_spec.path);
     } else if (!useStreaming) {
-      // stdout + json: streaming was skipped, write the formatted output now
       process.stdout.write(formatted);
       if (!formatted.endsWith('\n')) {
         process.stdout.write('\n');

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -16,7 +16,7 @@ describe('ValidatedCommandSchema — normalization', () => {
       prompt: 'Hello {{input}}',
       model: 'gpt-4o',
     });
-    expect(result.steps[0].model).toEqual({ name: 'gpt-4o' });
+    expect(result.steps[0].model).toEqual({ name: 'gpt-4o', provider: 'openai' });
   });
 
   it('promotes standalone prompt to steps[0]', () => {
@@ -37,6 +37,7 @@ describe('ValidatedCommandSchema — normalization', () => {
     });
     expect(result.steps[0].model).toEqual({
       name: 'gpt-4o-mini',
+      provider: 'openai',
       temperature: 0.5,
       max_tokens: 512,
     });
@@ -83,8 +84,8 @@ describe('ValidatedCommandSchema — extended config (multi-step)', () => {
     expect(result.steps).toHaveLength(2);
     expect(result.steps[1].depends_on).toEqual(['summarize']);
     // model string normalized in each step
-    expect(result.steps[0].model).toEqual({ name: 'gpt-4o-mini' });
-    expect(result.steps[1].model).toEqual({ name: 'gpt-4o' });
+    expect(result.steps[0].model).toEqual({ name: 'gpt-4o-mini', provider: 'openai' });
+    expect(result.steps[1].model).toEqual({ name: 'gpt-4o', provider: 'openai' });
   });
 
   it('defaults depends_on to [] when not provided in a step', () => {
@@ -170,6 +171,61 @@ describe('ValidatedCommandSchema — validation errors', () => {
         steps: [{ prompt: 'No id here', model: 'gpt-4o' }],
       }),
     ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider resolution tests
+// ---------------------------------------------------------------------------
+
+describe('ValidatedCommandSchema — provider resolution', () => {
+  it('sets provider to openai when explicitly specified', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hello',
+      model: { name: 'gpt-4o', provider: 'openai' },
+    });
+    expect(result.steps[0].model.provider).toBe('openai');
+  });
+
+  it('defaults provider to openai when omitted', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hello',
+      model: 'gpt-4o',
+    });
+    expect(result.steps[0].model.provider).toBe('openai');
+  });
+
+  it('propagates top-level model.provider to all steps', () => {
+    const result = ValidatedCommandSchema.parse({
+      model: { name: 'claude-3-5-sonnet', provider: 'anthropic' },
+      steps: [
+        { id: 'step1', prompt: 'First {{input}}', model: 'claude-3-5-sonnet', depends_on: [] },
+        { id: 'step2', prompt: 'Second', model: 'claude-3-5-sonnet', depends_on: ['step1'] },
+      ],
+    });
+    expect(result.steps[0].model.provider).toBe('anthropic');
+    expect(result.steps[1].model.provider).toBe('anthropic');
+  });
+
+  it('step-level provider overrides top-level provider', () => {
+    const result = ValidatedCommandSchema.parse({
+      model: { name: 'claude-3-5-sonnet', provider: 'anthropic' },
+      steps: [
+        { id: 'step1', prompt: 'Use openai', model: { name: 'gpt-4o', provider: 'openai' }, depends_on: [] },
+      ],
+    });
+    expect(result.steps[0].model.provider).toBe('openai');
+  });
+
+  it('each step can have its own model.provider in steps form', () => {
+    const result = ValidatedCommandSchema.parse({
+      steps: [
+        { id: 'step1', prompt: 'Anthropic step', model: { name: 'claude-3-5-sonnet', provider: 'anthropic' }, depends_on: [] },
+        { id: 'step2', prompt: 'Google step', model: { name: 'gemini-pro', provider: 'google' }, depends_on: ['step1'] },
+      ],
+    });
+    expect(result.steps[0].model.provider).toBe('anthropic');
+    expect(result.steps[1].model.provider).toBe('google');
   });
 });
 

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
-import type { ValidatedCommand } from '../types/index.js';
+import type { ProviderName, ValidatedCommand } from '../types/index.js';
+
+const PROVIDER_VALUES = ['openai', 'anthropic', 'google', 'ollama'] as const;
 
 const ModelSpecSchema = z.preprocess(
   (val) => (typeof val === 'string' ? { name: val } : val),
   z.object({
     name: z.string(),
+    provider: z.enum(PROVIDER_VALUES).optional(),
     temperature: z.number().optional(),
     max_tokens: z.number().int().optional(),
   })
@@ -85,6 +88,22 @@ export const ValidatedCommandSchema: z.ZodType<ValidatedCommand, z.ZodTypeDef, u
       ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Must provide either "prompt" or "steps"' });
       return z.NEVER;
     }
+
+    // Resolve top-level provider and propagate to steps
+    let topLevelProvider: ProviderName | undefined;
+    if (data.model !== undefined) {
+      const topLevelModelResult = ModelSpecSchema.safeParse(data.model);
+      if (topLevelModelResult.success) {
+        topLevelProvider = topLevelModelResult.data.provider;
+      }
+    }
+    steps = steps.map(step => ({
+      ...step,
+      model: {
+        ...step.model,
+        provider: step.model.provider ?? topLevelProvider ?? 'openai',
+      },
+    }));
 
     // Resolve input_spec
     let input_spec: ValidatedCommand['input_spec'];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,14 @@
+/** Supported LLM provider identifiers. */
+export type ProviderName = 'openai' | 'anthropic' | 'google' | 'ollama';
+
 /**
  * Describes the LLM model configuration for a step.
  * Used within Step, always normalized to object form by the Parser.
  */
 export interface ModelSpec {
   name: string;
+  /** LLM provider. Resolved by the Parser; defaults to 'openai' if omitted. */
+  provider?: ProviderName;
   temperature?: number;
   max_tokens?: number;
 }


### PR DESCRIPTION
## Summary

Executor 層をプロバイダーアダプターパターンにリファクタリングし、複数 LLM プロバイダーをサポートするための拡張可能な基盤を構築した。

## Changes

### New files
- \src/executor/adapters/types.ts\ — \LLMAdapter\ インターフェース + \createAdapter()\ ファクトリー
- \src/executor/adapters/openai.ts\ — \OpenAIAdapter\ クラス（\call()\ / \callStreaming(onChunk)\）
- \src/executor/adapters/openai.test.ts\ — \OpenAIAdapter\ 単体テスト (8 tests)
- \src/executor/api-key-resolver.ts\ — \esolveApiKey(provider)\ 関数

### Modified files
- \src/types/index.ts\ — \ProviderName\ 型と \ModelSpec.provider?\ フィールド追加
- \src/parser/schema.ts\ — \provider\ フィールド追加、トップレベルデフォルト伝播ロジック
- \src/executor/index.ts\ — アダプターパターンへ全面移行
- \src/executor/index.test.ts\ — API キーエラーアサーション更新
- \src/parser/index.test.ts\ — \provider\ 伝播ロジックのテスト追加

## Acceptance Criteria

- [x] \model.provider: openai\ を YAML に指定でき、既存動作が変わらない
- [x] \provider\ 省略時は \'openai'\ にデフォルト（後方互換）
- [x] API キー未設定時に \yali config set <provider>.api_key\ への案内が表示される
- [x] \LLMAdapter\ インターフェースが定義され、\OpenAIAdapter\ がそれを実装している
- [x] 全既存テストがパスする（127 tests）

Closes #22