### PR TITLE
feat: yali config command - OS-native API key management

### DIFF
--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -200,6 +200,7 @@ cat input.txt | yali run translate.yaml | jq '.result'
 **"The only layer that performs real I/O."**
 
 - Initialize and call the LLM API client (including retries)
+- **Resolve API keys via `src/config/` module** (config file only; environment variables are not consulted)
 - Handle streaming responses
 - Manage rate limits and errors
 - Dispatch multi-step steps sequentially or in parallel
@@ -207,6 +208,68 @@ cat input.txt | yali run translate.yaml | jq '.result'
 - **Returns: `ExecutionResult` (exit code and output content)**
 
 > **Invariant:** Changes to LLM APIs or adding MCP support are contained within the Executor (or its sub-adapters). Parser and Renderer remain unchanged.
+
+---
+
+## 4. Configuration Management
+
+### Overview
+
+`yali config` manages API keys for LLM providers in an OS-native config file. This eliminates the need for environment variables and centralizes key management.
+
+```bash
+yali config set openai.api_key sk-...      # Store a key
+yali config get openai.api_key             # Show masked key (sk-***...xxxx)
+yali config list                           # List all keys (masked)
+yali config unset openai.api_key           # Remove a key
+```
+
+### Config File Location
+
+| OS | Path |
+|---|---|
+| Linux / macOS | `$XDG_CONFIG_HOME/yali/config.yaml` (defaults to `~/.config/yali/config.yaml`) |
+| Windows | `%APPDATA%\yali\config.yaml` |
+
+Path resolution is implemented in `src/config/paths.ts` using `os.homedir()` with platform branching — no external dependencies.
+
+### Config File Format
+
+```yaml
+openai:
+  api_key: sk-...
+anthropic:
+  api_key: sk-ant-...
+google:
+  api_key: AIza...
+ollama:
+  base_url: http://localhost:11434
+```
+
+### Security
+
+- On Unix, the config file is protected with `chmod 600` (owner read/write only) — the same convention as SSH private keys (`~/.ssh/id_rsa`).
+- All `get` and `list` output masks API keys (`sk-***...xxxx`). Plain-text keys are never displayed.
+- The config file lives outside the repository (`~/.config/` or `%APPDATA%`), so it cannot be accidentally committed to git.
+
+### API Key Resolution
+
+API keys are resolved **from the config file only**. Environment variables (`OPENAI_API_KEY`, etc.) are not consulted.
+
+- Key found in config file → used as-is
+- Key absent or config file missing → `ExecutorError` with `yali config set <provider>.api_key` guidance
+
+This is implemented in `src/executor/api-key-resolver.ts`, which reads from `src/config/store.ts`.
+
+### Module Structure
+
+```
+src/config/
+  schema.ts    — zod schema for YaliConfig type
+  paths.ts     — OS-native config file path resolution
+  store.ts     — readConfig / writeConfig / getNestedValue / setNestedValue / unsetNestedValue
+  manager.ts   — handleConfigCommand: routes set/get/list/unset subcommands
+```
 
 ---
 
@@ -220,6 +283,7 @@ cat input.txt | yali run translate.yaml | jq '.result'
 | New input source (HTTP, etc.) | Input Resolver | Parser, Renderer, Executor |
 | YAML → TOML support | Parser only | All other layers |
 | `--dry-run` feature | CLI Layer → stops at Renderer | Executor |
+| New LLM provider / API key | `src/config/schema.ts`, Executor adapter | Parser, Renderer, CLI Layer |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { orderSteps, renderStep } from './renderer/index.js';
 import { execute } from './executor/index.js';
 import { resolveInput, InputResolverError } from './cli/input-resolver.js';
 import { formatDryRun } from './cli/dry-run-formatter.js';
+import { handleConfigCommand } from './config/manager.js';
 
 function printUsage(stream: NodeJS.WriteStream = process.stdout): void {
   stream.write(
@@ -24,6 +25,13 @@ function printUsage(stream: NodeJS.WriteStream = process.stdout): void {
 }
 
 export async function main(): Promise<void> {
+  // Handle `yali config` before generic arg parsing (config has its own arg structure)
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs[0] === 'config') {
+    await handleConfigCommand(rawArgs.slice(1));
+    process.exit(0);
+  }
+
   const { values, positionals } = parseArgs({
     args: process.argv.slice(2),
     options: {

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -20,12 +20,16 @@ vi.mock('./input-resolver.js', () => ({
 vi.mock('./dry-run-formatter.js', () => ({
   formatDryRun: vi.fn(),
 }));
+vi.mock('../config/manager.js', () => ({
+  handleConfigCommand: vi.fn(),
+}));
 
 import { parseCommand } from '../parser/index.js';
 import { execute } from '../executor/index.js';
 import { orderSteps, renderStep } from '../renderer/index.js';
 import { resolveInput } from './input-resolver.js';
 import { formatDryRun } from './dry-run-formatter.js';
+import { handleConfigCommand } from '../config/manager.js';
 import { main } from '../cli.js';
 
 const mockedParseCommand = vi.mocked(parseCommand);
@@ -34,6 +38,7 @@ const mockedOrderSteps = vi.mocked(orderSteps);
 const mockedRenderStep = vi.mocked(renderStep);
 const mockedResolveInput = vi.mocked(resolveInput);
 const mockedFormatDryRun = vi.mocked(formatDryRun);
+const mockedHandleConfigCommand = vi.mocked(handleConfigCommand);
 
 const MOCK_COMMAND = {
   steps: [{ id: 'step1', prompt: '{{input}}', model: { name: 'gpt-4o' }, depends_on: [] }],
@@ -74,6 +79,7 @@ describe('CLI Layer', () => {
     mockedOrderSteps.mockReturnValue(MOCK_COMMAND.steps);
     mockedRenderStep.mockReturnValue(MOCK_RENDERED_STEP);
     mockedFormatDryRun.mockReturnValue('=== Step: step1 ===\nHello, world');
+    mockedHandleConfigCommand.mockResolvedValue(undefined);
 
     // Simulate TTY (no piped stdin) by default
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
@@ -147,6 +153,13 @@ describe('CLI Layer', () => {
       expect.anything(),
       expect.objectContaining({ hasStdin: true }),
     );
+  });
+
+  it('routes "yali config" to handleConfigCommand and exits 0', async () => {
+    process.argv = ['node', 'cli.js', 'config', 'list'];
+    await expect(main()).rejects.toThrow('process.exit(0)');
+    expect(mockedHandleConfigCommand).toHaveBeenCalledWith(['list']);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('exits 0 and prints usage when --help is passed', async () => {

--- a/src/config/manager.test.ts
+++ b/src/config/manager.test.ts
@@ -80,6 +80,14 @@ describe('handleConfigCommand get', () => {
     ).rejects.toThrow('process.exit called');
     exitMock.mockRestore();
   });
+
+  it('exits with code 1 if key argument is missing', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(handleConfigCommand(['get'], configPath)).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -134,6 +142,14 @@ describe('handleConfigCommand unset', () => {
     await expect(
       handleConfigCommand(['unset', 'openai.api_key'], configPath),
     ).resolves.toBeUndefined();
+  });
+
+  it('exits with code 1 if key argument is missing', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(handleConfigCommand(['unset'], configPath)).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
   });
 });
 

--- a/src/config/manager.test.ts
+++ b/src/config/manager.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeConfig } from './store.js';
+import { handleConfigCommand, maskApiKey } from './manager.js';
+
+let tmpDir: string;
+let configPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'yali-test-'));
+  configPath = join(tmpDir, 'config.yaml');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// maskApiKey
+// ---------------------------------------------------------------------------
+describe('maskApiKey()', () => {
+  it('masks a long key as prefix***...suffix', () => {
+    expect(maskApiKey('sk-abcdefgh12345678')).toBe('sk-a***...5678');
+  });
+
+  it('returns **** for keys 8 chars or shorter', () => {
+    expect(maskApiKey('short')).toBe('****');
+    expect(maskApiKey('12345678')).toBe('****');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand — set
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand set', () => {
+  it('writes key to config file', async () => {
+    // Temporarily override getConfigPath via env
+    const { readConfig } = await import('./store.js');
+    // We test by directly using configPath
+    await handleConfigCommand(['set', 'openai.api_key', 'sk-test'], configPath);
+    const config = readConfig(configPath);
+    expect(config.openai?.api_key).toBe('sk-test');
+  });
+
+  it('exits with code 1 if value argument is missing', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(
+      handleConfigCommand(['set', 'openai.api_key'], configPath),
+    ).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand — get
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand get', () => {
+  it('prints masked key', async () => {
+    writeConfig(configPath, { openai: { api_key: 'sk-abcdefgh12345678' } });
+    const output: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((data: string | Uint8Array) => {
+      output.push(String(data));
+      return true;
+    });
+    await handleConfigCommand(['get', 'openai.api_key'], configPath);
+    expect(output.join('')).toContain('sk-a***...5678');
+    vi.restoreAllMocks();
+  });
+
+  it('exits with code 1 if key is not set', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(
+      handleConfigCommand(['get', 'openai.api_key'], configPath),
+    ).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand — list
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand list', () => {
+  it('prints "No configuration found." when file does not exist', async () => {
+    const output: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((data: string | Uint8Array) => {
+      output.push(String(data));
+      return true;
+    });
+    await handleConfigCommand(['list'], configPath);
+    expect(output.join('')).toContain('No configuration found.');
+    vi.restoreAllMocks();
+  });
+
+  it('prints all keys with masked values', async () => {
+    writeConfig(configPath, {
+      openai: { api_key: 'sk-abcdefgh12345678' },
+      anthropic: { api_key: 'ant-abcdefgh12345678' },
+    });
+    const output: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((data: string | Uint8Array) => {
+      output.push(String(data));
+      return true;
+    });
+    await handleConfigCommand(['list'], configPath);
+    const joined = output.join('');
+    expect(joined).toContain('openai.api_key');
+    expect(joined).toContain('anthropic.api_key');
+    vi.restoreAllMocks();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand — unset
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand unset', () => {
+  it('removes the key from config file', async () => {
+    writeConfig(configPath, { openai: { api_key: 'sk-test' } });
+    await handleConfigCommand(['unset', 'openai.api_key'], configPath);
+    const { readConfig } = await import('./store.js');
+    const config = readConfig(configPath);
+    expect(config.openai?.api_key).toBeUndefined();
+  });
+
+  it('exits 0 if key does not exist', async () => {
+    await expect(
+      handleConfigCommand(['unset', 'openai.api_key'], configPath),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand — unknown subcommand
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand unknown subcommand', () => {
+  it('exits with code 1 and usage error', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(
+      handleConfigCommand(['unknown'], configPath),
+    ).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
+});

--- a/src/config/manager.test.ts
+++ b/src/config/manager.test.ts
@@ -111,6 +111,9 @@ describe('handleConfigCommand list', () => {
     const joined = output.join('');
     expect(joined).toContain('openai.api_key');
     expect(joined).toContain('anthropic.api_key');
+    expect(joined).not.toContain('sk-abcdefgh12345678');
+    expect(joined).not.toContain('ant-abcdefgh12345678');
+    expect(joined).toContain('***');
     vi.restoreAllMocks();
   });
 });

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1,0 +1,149 @@
+import { getConfigPath } from './paths.js';
+import {
+  readConfig,
+  writeConfig,
+  getNestedValue,
+  setNestedValue,
+  unsetNestedValue,
+  ConfigError,
+} from './store.js';
+
+/** Masks an API key for safe display: sk-***...xxxx */
+export function maskApiKey(value: string): string {
+  if (value.length <= 8) {
+    return '****';
+  }
+  return `${value.slice(0, 4)}***...${value.slice(-4)}`;
+}
+
+/**
+ * Handles the `yali config` subcommand.
+ * Subcommands: set <key> <value> | get <key> | list | unset <key>
+ *
+ * @param args - CLI arguments after `config` (e.g. ['set', 'openai.api_key', 'sk-...'])
+ * @param configFilePath - Override the config file path (used in tests with tmpdir)
+ */
+export async function handleConfigCommand(
+  args: string[],
+  configFilePath?: string,
+): Promise<void> {
+  const configPath = configFilePath ?? getConfigPath();
+  const [subcommand, ...rest] = args;
+
+  switch (subcommand) {
+    case 'set': {
+      const [key, value] = rest;
+      if (!key || !value) {
+        process.stderr.write('Usage: yali config set <key> <value>\n');
+        process.stderr.write('Example: yali config set openai.api_key sk-...\n');
+        process.exit(1);
+      }
+      try {
+        const config = readConfig(configPath);
+        const updated = setNestedValue(config, key, value);
+        writeConfig(configPath, updated);
+        process.stdout.write(`✓ Set ${key}\n`);
+      } catch (e) {
+        process.stderr.write(`Error: ${e instanceof ConfigError ? e.message : String(e)}\n`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'get': {
+      const [key] = rest;
+      if (!key) {
+        process.stderr.write('Usage: yali config get <key>\n');
+        process.exit(1);
+      }
+      try {
+        const config = readConfig(configPath);
+        const value = getNestedValue(config, key);
+        if (value === undefined) {
+          process.stderr.write(`Error: "${key}" is not set. Run: yali config set ${key} <value>\n`);
+          process.exit(1);
+        }
+        process.stdout.write(`${maskApiKey(value)}\n`);
+      } catch (e) {
+        process.stderr.write(`Error: ${e instanceof ConfigError ? e.message : String(e)}\n`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'list': {
+      try {
+        const config = readConfig(configPath);
+        const entries = collectEntries(config);
+        if (entries.length === 0) {
+          process.stdout.write('No configuration found.\n');
+          break;
+        }
+        for (const { key, value } of entries) {
+          process.stdout.write(`${key} = ${maskApiKey(value)}\n`);
+        }
+      } catch (e) {
+        process.stderr.write(`Error: ${e instanceof ConfigError ? e.message : String(e)}\n`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'unset': {
+      const [key] = rest;
+      if (!key) {
+        process.stderr.write('Usage: yali config unset <key>\n');
+        process.exit(1);
+      }
+      try {
+        const config = readConfig(configPath);
+        const updated = unsetNestedValue(config, key);
+        writeConfig(configPath, updated);
+        process.stdout.write(`✓ Unset ${key}\n`);
+      } catch (e) {
+        process.stderr.write(`Error: ${e instanceof ConfigError ? e.message : String(e)}\n`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    default: {
+      process.stderr.write(
+        [
+          'Usage: yali config <subcommand>',
+          '',
+          'Subcommands:',
+          '  set <key> <value>   Set a configuration value',
+          '  get <key>           Get a configuration value (masked)',
+          '  list                List all configuration values (masked)',
+          '  unset <key>         Remove a configuration value',
+          '',
+          'Examples:',
+          '  yali config set openai.api_key sk-...',
+          '  yali config get openai.api_key',
+          '  yali config list',
+          '  yali config unset openai.api_key',
+          '',
+        ].join('\n'),
+      );
+      process.exit(1);
+    }
+  }
+}
+
+/** Recursively collects all leaf string entries from a nested config object. */
+function collectEntries(
+  obj: Record<string, unknown>,
+  prefix = '',
+): Array<{ key: string; value: string }> {
+  const entries: Array<{ key: string; value: string }> = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === 'string') {
+      entries.push({ key: fullKey, value: v });
+    } else if (v !== null && typeof v === 'object') {
+      entries.push(...collectEntries(v as Record<string, unknown>, fullKey));
+    }
+  }
+  return entries;
+}

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { getConfigPath } from './paths.js';
+
+const originalPlatform = process.platform;
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('getConfigPath()', () => {
+  it('returns XDG_CONFIG_HOME-based path when XDG_CONFIG_HOME is set', () => {
+    if (process.platform === 'win32') return; // skip on Windows
+    process.env['XDG_CONFIG_HOME'] = '/custom/config';
+    const path = getConfigPath();
+    expect(path).toBe('/custom/config/yali/config.yaml');
+  });
+
+  it('returns ~/.config/yali/config.yaml when XDG_CONFIG_HOME is unset (Linux/macOS)', () => {
+    if (process.platform === 'win32') return; // skip on Windows
+    delete process.env['XDG_CONFIG_HOME'];
+    const path = getConfigPath();
+    expect(path).toBe(join(homedir(), '.config', 'yali', 'config.yaml'));
+  });
+
+  it('returns %APPDATA%/yali/config.yaml on Windows', () => {
+    if (process.platform !== 'win32') return; // only run on Windows
+    process.env['APPDATA'] = 'C:\\Users\\test\\AppData\\Roaming';
+    const path = getConfigPath();
+    expect(path).toBe('C:\\Users\\test\\AppData\\Roaming\\yali\\config.yaml');
+  });
+
+  it('returns a path ending with config.yaml', () => {
+    const path = getConfigPath();
+    expect(path.endsWith('config.yaml')).toBe(true);
+  });
+
+  it('returns a path containing "yali"', () => {
+    const path = getConfigPath();
+    expect(path).toContain('yali');
+  });
+});

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -11,22 +11,19 @@ afterEach(() => {
 });
 
 describe('getConfigPath()', () => {
-  it('returns XDG_CONFIG_HOME-based path when XDG_CONFIG_HOME is set', () => {
-    if (process.platform === 'win32') return; // skip on Windows
+  it.skipIf(process.platform === 'win32')('returns XDG_CONFIG_HOME-based path when XDG_CONFIG_HOME is set', () => {
     process.env['XDG_CONFIG_HOME'] = '/custom/config';
     const path = getConfigPath();
     expect(path).toBe('/custom/config/yali/config.yaml');
   });
 
-  it('returns ~/.config/yali/config.yaml when XDG_CONFIG_HOME is unset (Linux/macOS)', () => {
-    if (process.platform === 'win32') return; // skip on Windows
+  it.skipIf(process.platform === 'win32')('returns ~/.config/yali/config.yaml when XDG_CONFIG_HOME is unset (Linux/macOS)', () => {
     delete process.env['XDG_CONFIG_HOME'];
     const path = getConfigPath();
     expect(path).toBe(join(homedir(), '.config', 'yali', 'config.yaml'));
   });
 
-  it('returns %APPDATA%/yali/config.yaml on Windows', () => {
-    if (process.platform !== 'win32') return; // only run on Windows
+  it.skipIf(process.platform !== 'win32')('returns %APPDATA%/yali/config.yaml on Windows', () => {
     process.env['APPDATA'] = 'C:\\Users\\test\\AppData\\Roaming';
     const path = getConfigPath();
     expect(path).toBe('C:\\Users\\test\\AppData\\Roaming\\yali\\config.yaml');

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,0 +1,18 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Returns the OS-native path to the yali config file.
+ *
+ * - Linux/macOS: $XDG_CONFIG_HOME/yali/config.yaml (defaults to ~/.config/yali/config.yaml)
+ * - Windows:     %APPDATA%\yali\config.yaml
+ */
+export function getConfigPath(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA'] ?? join(homedir(), 'AppData', 'Roaming');
+    return join(appData, 'yali', 'config.yaml');
+  }
+
+  const xdgConfigHome = process.env['XDG_CONFIG_HOME'] ?? join(homedir(), '.config');
+  return join(xdgConfigHome, 'yali', 'config.yaml');
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const ProviderConfigSchema = z.object({
+  api_key: z.string().optional(),
+  base_url: z.string().optional(),
+});
+
+export const YaliConfigSchema = z.object({
+  openai: ProviderConfigSchema.optional(),
+  anthropic: ProviderConfigSchema.optional(),
+  google: ProviderConfigSchema.optional(),
+  ollama: ProviderConfigSchema.optional(),
+});
+
+export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
+export type YaliConfig = z.infer<typeof YaliConfigSchema>;

--- a/src/config/store.test.ts
+++ b/src/config/store.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+import {
+  readConfig,
+  writeConfig,
+  getNestedValue,
+  setNestedValue,
+  unsetNestedValue,
+  ConfigError,
+} from './store.js';
+
+const isWindows = platform() === 'win32';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'yali-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// readConfig
+// ---------------------------------------------------------------------------
+describe('readConfig()', () => {
+  it('returns empty object when file does not exist', () => {
+    const result = readConfig(join(tmpDir, 'config.yaml'));
+    expect(result).toEqual({});
+  });
+
+  it('returns empty object when file is empty', () => {
+    const path = join(tmpDir, 'config.yaml');
+    writeConfig(path, {});
+    const result = readConfig(path);
+    expect(result).toEqual({});
+  });
+
+  it('parses valid YAML into config object', () => {
+    const path = join(tmpDir, 'config.yaml');
+    writeConfig(path, { openai: { api_key: 'sk-test' } });
+    const result = readConfig(path);
+    expect(result.openai?.api_key).toBe('sk-test');
+  });
+
+  it('throws ConfigError when YAML is malformed', () => {
+    const path = join(tmpDir, 'config.yaml');
+    writeFileSync(path, 'openai: [invalid: yaml: {{{');
+    expect(() => readConfig(path)).toThrow(ConfigError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeConfig
+// ---------------------------------------------------------------------------
+describe('writeConfig()', () => {
+  it('creates parent directories if they do not exist', () => {
+    const path = join(tmpDir, 'nested', 'dir', 'config.yaml');
+    expect(() => writeConfig(path, { openai: { api_key: 'sk-test' } })).not.toThrow();
+    expect(readConfig(path).openai?.api_key).toBe('sk-test');
+  });
+
+  it('writes config as YAML to the specified path', () => {
+    const path = join(tmpDir, 'config.yaml');
+    writeConfig(path, { anthropic: { api_key: 'ant-key' } });
+    const result = readConfig(path);
+    expect(result.anthropic?.api_key).toBe('ant-key');
+  });
+
+  it.skipIf(isWindows)('sets file permissions to 0o600 on Unix', async () => {
+    const { statSync } = await import('node:fs');
+    const path = join(tmpDir, 'config.yaml');
+    writeConfig(path, {});
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('overwrites existing file without losing other keys', () => {
+    const path = join(tmpDir, 'config.yaml');
+    writeConfig(path, { openai: { api_key: 'sk-test' } });
+    const config = readConfig(path);
+    const updated = setNestedValue(config, 'anthropic.api_key', 'ant-key');
+    writeConfig(path, updated);
+    const result = readConfig(path);
+    expect(result.openai?.api_key).toBe('sk-test');
+    expect(result.anthropic?.api_key).toBe('ant-key');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNestedValue
+// ---------------------------------------------------------------------------
+describe('getNestedValue()', () => {
+  it('returns value for a valid dotted key path', () => {
+    const config = { openai: { api_key: 'sk-test' } };
+    expect(getNestedValue(config, 'openai.api_key')).toBe('sk-test');
+  });
+
+  it('returns undefined for a missing key path', () => {
+    expect(getNestedValue({}, 'openai.api_key')).toBeUndefined();
+  });
+
+  it('returns undefined when intermediate key is missing', () => {
+    expect(getNestedValue({}, 'anthropic.api_key')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setNestedValue
+// ---------------------------------------------------------------------------
+describe('setNestedValue()', () => {
+  it('sets value at dotted key path in config object', () => {
+    const config = { openai: { api_key: 'old' } };
+    const result = setNestedValue(config, 'openai.api_key', 'new');
+    expect(result.openai?.api_key).toBe('new');
+  });
+
+  it('creates intermediate objects if they do not exist', () => {
+    const result = setNestedValue({}, 'openai.api_key', 'sk-test');
+    expect(result.openai?.api_key).toBe('sk-test');
+  });
+
+  it('does not mutate the original config', () => {
+    const config = { openai: { api_key: 'original' } };
+    setNestedValue(config, 'openai.api_key', 'changed');
+    expect(config.openai.api_key).toBe('original');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unsetNestedValue
+// ---------------------------------------------------------------------------
+describe('unsetNestedValue()', () => {
+  it('removes key at dotted path', () => {
+    const config = { openai: { api_key: 'sk-test' } };
+    const result = unsetNestedValue(config, 'openai.api_key');
+    expect(result.openai?.api_key).toBeUndefined();
+  });
+
+  it('does nothing if key does not exist', () => {
+    expect(() => unsetNestedValue({}, 'openai.api_key')).not.toThrow();
+  });
+
+  it('does not mutate the original config', () => {
+    const config = { openai: { api_key: 'sk-test' } };
+    unsetNestedValue(config, 'openai.api_key');
+    expect(config.openai?.api_key).toBe('sk-test');
+  });
+});

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -1,0 +1,124 @@
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import * as yaml from 'js-yaml';
+import { YaliConfigSchema, type YaliConfig } from './schema.js';
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigError';
+  }
+}
+
+/**
+ * Reads the config file at the given path and returns a parsed YaliConfig.
+ * Returns an empty config object if the file does not exist or is empty.
+ * Throws ConfigError if the YAML is malformed or fails schema validation.
+ */
+export function readConfig(filePath: string): YaliConfig {
+  if (!existsSync(filePath)) {
+    return {};
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (e) {
+    throw new ConfigError(`Failed to read config file: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (!raw.trim()) {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw);
+  } catch (e) {
+    throw new ConfigError(`Config file contains invalid YAML: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const result = YaliConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new ConfigError(`Config file has invalid structure: ${result.error.message}`);
+  }
+
+  return result.data;
+}
+
+/**
+ * Writes the given config object as YAML to filePath.
+ * Creates parent directories as needed.
+ * On Unix, sets file permissions to 0o600 (owner read/write only).
+ */
+export function writeConfig(filePath: string, config: YaliConfig): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+
+  const content = yaml.dump(config, { indent: 2 });
+  writeFileSync(filePath, content, 'utf8');
+
+  if (process.platform !== 'win32') {
+    chmodSync(filePath, 0o600);
+  }
+}
+
+/**
+ * Gets a value from config using a dotted key path (e.g. 'openai.api_key').
+ * Returns undefined if any part of the path is missing.
+ */
+export function getNestedValue(config: YaliConfig, keyPath: string): string | undefined {
+  const parts = keyPath.split('.');
+  let current: unknown = config;
+  for (const part of parts) {
+    if (current === null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return typeof current === 'string' ? current : undefined;
+}
+
+/**
+ * Sets a value in config using a dotted key path.
+ * Creates intermediate objects as needed.
+ * Returns a new config object with the value set.
+ */
+export function setNestedValue(config: YaliConfig, keyPath: string, value: string): YaliConfig {
+  const parts = keyPath.split('.');
+  const result = structuredClone(config) as Record<string, unknown>;
+
+  let current = result;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]!;
+    if (typeof current[part] !== 'object' || current[part] === null) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]!] = value;
+
+  return result as YaliConfig;
+}
+
+/**
+ * Removes a value from config using a dotted key path.
+ * Returns a new config object with the key removed.
+ * Does nothing if the key does not exist.
+ */
+export function unsetNestedValue(config: YaliConfig, keyPath: string): YaliConfig {
+  const parts = keyPath.split('.');
+  const result = structuredClone(config) as Record<string, unknown>;
+
+  let current = result;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]!;
+    if (typeof current[part] !== 'object' || current[part] === null) {
+      return result as YaliConfig;
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  delete current[parts[parts.length - 1]!];
+
+  return result as YaliConfig;
+}

--- a/src/executor/api-key-resolver.test.ts
+++ b/src/executor/api-key-resolver.test.ts
@@ -1,74 +1,79 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeConfig } from '../config/store.js';
 import { resolveApiKey } from './api-key-resolver.js';
 import { ExecutorError } from './errors.js';
 
-const ALL_ENV_VARS = [
-  'OPENAI_API_KEY',
-  'ANTHROPIC_API_KEY',
-  'GOOGLE_API_KEY',
-  'OLLAMA_API_KEY',
-] as const;
+let tmpDir: string;
+let configPath: string;
+
+// Hoisted mock — factory reads `configPath` at call time via closure
+vi.mock('../config/paths.js', () => ({
+  getConfigPath: () => configPath,
+}));
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'yali-test-'));
+  configPath = join(tmpDir, 'config.yaml');
+});
 
 afterEach(() => {
-  for (const key of ALL_ENV_VARS) {
-    delete process.env[key];
-  }
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe('resolveApiKey()', () => {
-  // ---------------------------------------------------------------------------
-  // openai
-  // ---------------------------------------------------------------------------
-  it('returns the key when OPENAI_API_KEY is set', () => {
-    process.env['OPENAI_API_KEY'] = 'sk-test-openai';
-    expect(resolveApiKey('openai')).toBe('sk-test-openai');
+  it('returns api_key from config file for openai', () => {
+    writeConfig(configPath, { openai: { api_key: 'sk-from-config' } });
+    expect(resolveApiKey('openai')).toBe('sk-from-config');
   });
 
-  it('throws ExecutorError when OPENAI_API_KEY is not set', () => {
+  it('returns api_key from config file for anthropic', () => {
+    writeConfig(configPath, { anthropic: { api_key: 'ant-from-config' } });
+    expect(resolveApiKey('anthropic')).toBe('ant-from-config');
+  });
+
+  it('returns api_key from config file for google', () => {
+    writeConfig(configPath, { google: { api_key: 'goog-from-config' } });
+    expect(resolveApiKey('google')).toBe('goog-from-config');
+  });
+
+  it('returns api_key from config file for ollama', () => {
+    writeConfig(configPath, { ollama: { api_key: 'ollama-from-config' } });
+    expect(resolveApiKey('ollama')).toBe('ollama-from-config');
+  });
+
+  it('throws ExecutorError when config file does not exist', () => {
     expect(() => resolveApiKey('openai')).toThrow(ExecutorError);
   });
 
-  it('error message mentions the env var name for openai', () => {
-    expect(() => resolveApiKey('openai')).toThrow(/OPENAI_API_KEY/);
+  it('throws ExecutorError when api_key is missing from config', () => {
+    writeConfig(configPath, { openai: {} });
+    expect(() => resolveApiKey('openai')).toThrow(ExecutorError);
   });
 
-  it('error message includes yali config set guidance for openai', () => {
+  it('error message includes yali config set guidance', () => {
     expect(() => resolveApiKey('openai')).toThrow(/yali config set openai\.api_key/);
   });
 
-  // ---------------------------------------------------------------------------
-  // Provider → env var mapping
-  // ---------------------------------------------------------------------------
-  it('maps anthropic to ANTHROPIC_API_KEY', () => {
-    process.env['ANTHROPIC_API_KEY'] = 'ant-key';
-    expect(resolveApiKey('anthropic')).toBe('ant-key');
-  });
-
-  it('maps google to GOOGLE_API_KEY', () => {
-    process.env['GOOGLE_API_KEY'] = 'goog-key';
-    expect(resolveApiKey('google')).toBe('goog-key');
-  });
-
-  it('maps ollama to OLLAMA_API_KEY', () => {
-    process.env['OLLAMA_API_KEY'] = 'ollama-key';
-    expect(resolveApiKey('ollama')).toBe('ollama-key');
-  });
-
-  // ---------------------------------------------------------------------------
-  // Error messages for other providers
-  // ---------------------------------------------------------------------------
-  it('throws when anthropic key is missing with correct guidance', () => {
-    expect(() => resolveApiKey('anthropic')).toThrow(/yali config set anthropic\.api_key/);
-  });
-
-  it('error message for anthropic mentions ANTHROPIC_API_KEY', () => {
-    expect(() => resolveApiKey('anthropic')).toThrow(/ANTHROPIC_API_KEY/);
-  });
-
-  it('error message includes capitalised provider label', () => {
-    // "OpenAI API key is not configured"
+  it('error message includes provider label for openai', () => {
     expect(() => resolveApiKey('openai')).toThrow(/OpenAI/);
-    // "Anthropic API key is not configured"
+  });
+
+  it('error message includes provider label for anthropic', () => {
     expect(() => resolveApiKey('anthropic')).toThrow(/Anthropic/);
   });
+
+  it('does NOT read environment variables even if set', () => {
+    process.env['OPENAI_API_KEY'] = 'sk-should-not-be-used';
+    try {
+      // Should throw because config file has no key, despite env var being set
+      expect(() => resolveApiKey('openai')).toThrow(ExecutorError);
+    } finally {
+      delete process.env['OPENAI_API_KEY'];
+    }
+  });
 });
+
+

--- a/src/executor/api-key-resolver.ts
+++ b/src/executor/api-key-resolver.ts
@@ -1,13 +1,7 @@
 import type { ProviderName } from '../types/index.js';
 import { ExecutorError } from './errors.js';
-
-/** Maps provider names to their environment variable names. */
-const ENV_VAR_MAP: Record<ProviderName, string> = {
-  openai: 'OPENAI_API_KEY',
-  anthropic: 'ANTHROPIC_API_KEY',
-  google: 'GOOGLE_API_KEY',
-  ollama: 'OLLAMA_API_KEY',
-};
+import { getConfigPath } from '../config/paths.js';
+import { readConfig, getNestedValue } from '../config/store.js';
 
 /** Human-readable display names for each provider. */
 const PROVIDER_LABELS: Record<ProviderName, string> = {
@@ -18,17 +12,24 @@ const PROVIDER_LABELS: Record<ProviderName, string> = {
 };
 
 /**
- * Resolves the API key for the given provider.
+ * Resolves the API key for the given provider from the yali config file.
  *
- * Resolution order:
- *   1. Environment variable (backward compatible)
- *   2. (Future) ~/.config/yali/config.yaml — to be implemented with yali config issue
+ * Resolution: ~/.config/yali/config.yaml (or OS equivalent) only.
+ * Environment variables are not consulted.
  *
  * Throws ExecutorError with user-friendly guidance if the key is not configured.
  */
 export function resolveApiKey(provider: ProviderName): string {
-  const envVar = ENV_VAR_MAP[provider];
-  const apiKey = process.env[envVar];
+  const configPath = getConfigPath();
+  let apiKey: string | undefined;
+
+  try {
+    const config = readConfig(configPath);
+    apiKey = getNestedValue(config, `${provider}.api_key`);
+  } catch {
+    // If the config file is unreadable/malformed, fall through to the error below
+  }
+
   if (apiKey) {
     return apiKey;
   }
@@ -36,7 +37,6 @@ export function resolveApiKey(provider: ProviderName): string {
   const providerLabel = PROVIDER_LABELS[provider];
   throw new ExecutorError(
     `${providerLabel} API key is not configured.\n` +
-      `Set the ${envVar} environment variable, or run:\n` +
-      `  yali config set ${provider}.api_key <YOUR_API_KEY>`,
+      `Run: yali config set ${provider}.api_key <YOUR_API_KEY>`,
   );
 }

--- a/src/executor/index.test.ts
+++ b/src/executor/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ValidatedCommand } from '../types/index.js';
+import { ExecutorError } from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Mock the openai module before importing the executor
@@ -30,6 +31,11 @@ vi.mock('openai', () => {
   return { default: OpenAI, __mockCreate: mockCreate };
 });
 
+// Mock api-key-resolver so tests don't depend on config file existence
+vi.mock('./api-key-resolver.js', () => ({
+  resolveApiKey: vi.fn().mockReturnValue('test-key'),
+}));
+
 // ---------------------------------------------------------------------------
 // Helper: build a minimal ValidatedCommand
 // ---------------------------------------------------------------------------
@@ -57,7 +63,6 @@ describe('execute()', () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    process.env['OPENAI_API_KEY'] = 'test-key';
 
     // Re-import after reset to pick up the mock
     const openaiModule = await import('openai') as unknown as { __mockCreate: ReturnType<typeof vi.fn> };
@@ -66,7 +71,6 @@ describe('execute()', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    delete process.env['OPENAI_API_KEY'];
   });
 
   // Helper: makes mockCreate return a non-streaming response
@@ -89,8 +93,11 @@ describe('execute()', () => {
   // ---------------------------------------------------------------------------
   // Missing API key
   // ---------------------------------------------------------------------------
-  it('returns exitCode 1 when OPENAI_API_KEY is missing', async () => {
-    delete process.env['OPENAI_API_KEY'];
+  it('returns exitCode 1 when API key is not configured', async () => {
+    const { resolveApiKey } = await import('./api-key-resolver.js') as { resolveApiKey: ReturnType<typeof vi.fn> };
+    resolveApiKey.mockImplementationOnce(() => {
+      throw new ExecutorError('OpenAI API key is not configured.\nRun: yali config set openai.api_key <YOUR_API_KEY>');
+    });
     const { execute } = await import('./index.js');
     const result = await execute(makeCommand(), { input: 'world' });
     expect(result.exitCode).toBe(1);


### PR DESCRIPTION
## Summary

Implements the `yali config` command for OS-native API key management, resolving #23.

API keys are stored exclusively in a config file (no environment variable fallback). The config file follows OS conventions:
- **Linux/macOS**: `$XDG_CONFIG_HOME/yali/config.yaml` (defaults to `~/.config/yali/config.yaml`)
- **Windows**: `%APPDATA%\yali\config.yaml`

## Changes

### New: `src/config/` module

| File | Description |
|---|---|
| `schema.ts` | Zod schema for `YaliConfig` type — defines allowed YAML structure |
| `paths.ts` | OS-native config path resolution |
| `store.ts` | Read/write config file; `chmod 600` on Unix for security |
| `manager.ts` | `handleConfigCommand` — implements `set`/`get`/`list`/`unset` subcommands |

### Modified

- **`src/cli.ts`**: Intercepts `yali config` before generic arg parsing
- **`src/executor/api-key-resolver.ts`**: Reads API key from config file only (env var lookup removed)
- **`docs/spec-draft.md`**: Added Section 4 "Configuration Management"; updated Executor responsibilities and Change Resilience table

## Subcommands

```
yali config set <key> <value>   # e.g. yali config set openai.api_key sk-...
yali config get <key>           # prints masked value
yali config list                # lists all keys with masked values
yali config unset <key>         # removes a key
```

## Security

- Config file permissions: `chmod 600` on Unix (owner read/write only)
- `get` and `list` always mask output: `sk-a***...5678` (keys 8 chars or shorter -> `****`)
- Config file lives in OS user config dir, outside any git repo

## Testing

- 175 tests pass, 3 skipped (platform-specific chmod/path tests)
- Real tmpdir isolation (no `vi.mock` for filesystem)
- Full coverage: set/get/list/unset, edge cases, masking, missing-key errors, chmod

Closes #23
