### PR TITLE
feat: Google Gemini プロバイダー実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
+        "@google/generative-ai": "^0.24.1",
         "js-yaml": "^4.1.0",
         "openai": "^4.98.0",
         "zod": "^3.25.76"
@@ -495,6 +496,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@google/generative-ai": "^0.24.1",
     "js-yaml": "^4.1.0",
     "openai": "^4.98.0",
     "zod": "^3.25.76"

--- a/src/executor/adapters/gemini.test.ts
+++ b/src/executor/adapters/gemini.test.ts
@@ -160,4 +160,68 @@ describe('GeminiAdapter', () => {
     const result = await adapter.callStreaming('prompt', { name: 'gemini-pro' }, () => {});
     expect(result).toBe('Hello world!');
   });
+
+  // call() — 500 でリトライし成功する
+  it('call() retries on 500 (server error) and succeeds', async () => {
+    vi.useFakeTimers();
+    const serverError = Object.assign(new Error('internal server error'), { status: 500 });
+    mockGenerateContent
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce({ response: { text: () => 'recovered' } });
+
+    const adapter = new GeminiAdapter('test-key');
+    const promise = adapter.call('prompt', { name: 'gemini-1.5-flash' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // callStreaming() — 429 でリトライし成功する
+  it('callStreaming() retries on 429 and succeeds', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+
+    async function* successStream() {
+      yield { text: () => 'streamed ok' };
+    }
+
+    mockGenerateContentStream
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ stream: successStream() });
+
+    const adapter = new GeminiAdapter('test-key');
+    const chunks: string[] = [];
+    const promise = adapter.callStreaming('prompt', { name: 'gemini-1.5-flash' }, (c) => chunks.push(c));
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('streamed ok');
+    expect(chunks).toEqual(['streamed ok']);
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // callStreaming() — MAX_RETRIES 回失敗後 ExecutorError をスロー
+  it('callStreaming() throws ExecutorError after exhausting all retries', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContentStream.mockRejectedValue(rateLimitError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter.callStreaming('prompt', { name: 'gemini-1.5-flash' }, () => {}).catch((e) => {
+      caughtError = e;
+    });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    vi.useRealTimers();
+  });
 });

--- a/src/executor/adapters/gemini.test.ts
+++ b/src/executor/adapters/gemini.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGenerateContent = vi.fn();
+const mockGenerateContentStream = vi.fn();
+
+vi.mock('@google/generative-ai', () => {
+  const GoogleGenerativeAI = vi.fn().mockImplementation(() => ({
+    getGenerativeModel: vi.fn().mockReturnValue({
+      generateContent: mockGenerateContent,
+      generateContentStream: mockGenerateContentStream,
+    }),
+  }));
+  return { GoogleGenerativeAI };
+});
+
+describe('GeminiAdapter', () => {
+  let GeminiAdapter: new (apiKey: string) => import('./gemini.js').GeminiAdapter;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    ({ GeminiAdapter } = await import('./gemini.js'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  function mockNonStreaming(text: string) {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => text },
+    });
+  }
+
+  async function* makeStreamChunks(texts: string[]) {
+    for (const t of texts) {
+      yield { text: () => t };
+    }
+  }
+
+  function mockStreaming(texts: string[]) {
+    mockGenerateContentStream.mockResolvedValue({
+      stream: makeStreamChunks(texts),
+    });
+  }
+
+  // call() — 正常系
+  it('call() returns the response text', async () => {
+    mockNonStreaming('Hello, world!');
+    const adapter = new GeminiAdapter('test-key');
+    const result = await adapter.call('Say hello', { name: 'gemini-pro' });
+    expect(result).toBe('Hello, world!');
+  });
+
+  // call() — temperature, maxOutputTokens が API に渡される
+  it('call() forwards temperature and maxOutputTokens to the model config', async () => {
+    mockNonStreaming('result');
+    const { GoogleGenerativeAI } = await import('@google/generative-ai');
+    const mockGetGenerativeModel = vi.fn().mockReturnValue({
+      generateContent: mockGenerateContent,
+      generateContentStream: mockGenerateContentStream,
+    });
+    (GoogleGenerativeAI as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      getGenerativeModel: mockGetGenerativeModel,
+    }));
+
+    const adapter = new GeminiAdapter('test-key');
+    await adapter.call('prompt', { name: 'gemini-pro', temperature: 0.7, max_tokens: 256 });
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generationConfig: expect.objectContaining({ temperature: 0.7, maxOutputTokens: 256 }),
+      }),
+    );
+  });
+
+  // call() — 429 でリトライし成功する
+  it('call() retries on 429 and succeeds', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContent
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ response: { text: () => 'retry success' } });
+
+    const adapter = new GeminiAdapter('test-key');
+    const promise = adapter.call('prompt', { name: 'gemini-pro' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('retry success');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // call() — MAX_RETRIES 回失敗後 ExecutorError をスロー
+  it('call() throws ExecutorError after exhausting all retries', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContent.mockRejectedValue(rateLimitError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter.call('prompt', { name: 'gemini-pro' }).catch((e) => {
+      caughtError = e;
+    });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContent).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  // call() — 400 (non-retryable) はリトライしない
+  it('call() does not retry on 400 (non-retryable)', async () => {
+    const badRequestError = Object.assign(new Error('bad request'), { status: 400 });
+    mockGenerateContent.mockRejectedValue(badRequestError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(adapter.call('prompt', { name: 'gemini-pro' })).rejects.toBeInstanceOf(
+      ExecutorError,
+    );
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — ECONNRESET でリトライし成功する
+  it('call() retries on ECONNRESET and succeeds', async () => {
+    vi.useFakeTimers();
+    const networkError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    mockGenerateContent
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({ response: { text: () => 'network retry ok' } });
+
+    const adapter = new GeminiAdapter('test-key');
+    const promise = adapter.call('prompt', { name: 'gemini-pro' });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('network retry ok');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  // callStreaming() — chunks が onChunk コールバックで返される
+  it('callStreaming() invokes onChunk for each chunk', async () => {
+    mockStreaming(['Hello ', 'world!']);
+    const adapter = new GeminiAdapter('test-key');
+    const chunks: string[] = [];
+    await adapter.callStreaming('prompt', { name: 'gemini-pro' }, (c) => chunks.push(c));
+    expect(chunks).toEqual(['Hello ', 'world!']);
+  });
+
+  // callStreaming() — 累積テキストを返す
+  it('callStreaming() returns the accumulated full text', async () => {
+    mockStreaming(['Hello ', 'world!']);
+    const adapter = new GeminiAdapter('test-key');
+    const result = await adapter.callStreaming('prompt', { name: 'gemini-pro' }, () => {});
+    expect(result).toBe('Hello world!');
+  });
+});

--- a/src/executor/adapters/gemini.ts
+++ b/src/executor/adapters/gemini.ts
@@ -1,0 +1,96 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { ModelSpec } from '../../types/index.js';
+import { ExecutorError } from '../errors.js';
+import type { LLMAdapter } from './types.js';
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof Error) {
+    if ('code' in error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ENOTFOUND') return true;
+    }
+    const status = (error as unknown as Record<string, unknown>)['status'];
+    if (typeof status === 'number') {
+      return RETRYABLE_STATUS_CODES.has(status);
+    }
+  }
+  return false;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class GeminiAdapter implements LLMAdapter {
+  private readonly client: GoogleGenerativeAI;
+
+  constructor(apiKey: string) {
+    this.client = new GoogleGenerativeAI(apiKey);
+  }
+
+  async call(prompt: string, model: ModelSpec): Promise<string> {
+    const { name: modelName, temperature, max_tokens } = model;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
+
+      try {
+        const genModel = this.client.getGenerativeModel({
+          model: modelName,
+          generationConfig: {
+            ...(temperature !== undefined && { temperature }),
+            ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
+          },
+        });
+        const result = await genModel.generateContent(prompt);
+        return result.response.text();
+      } catch (error) {
+        lastError = error;
+        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+          break;
+        }
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new ExecutorError(
+      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      lastError,
+    );
+  }
+
+  async callStreaming(
+    prompt: string,
+    model: ModelSpec,
+    onChunk: (chunk: string) => void,
+  ): Promise<string> {
+    const { name: modelName, temperature, max_tokens } = model;
+
+    const genModel = this.client.getGenerativeModel({
+      model: modelName,
+      generationConfig: {
+        ...(temperature !== undefined && { temperature }),
+        ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
+      },
+    });
+    const result = await genModel.generateContentStream(prompt);
+
+    let fullText = '';
+    for await (const chunk of result.stream) {
+      const text = chunk.text();
+      if (text) {
+        onChunk(text);
+        fullText += text;
+      }
+    }
+    return fullText;
+  }
+}

--- a/src/executor/adapters/gemini.ts
+++ b/src/executor/adapters/gemini.ts
@@ -73,24 +73,45 @@ export class GeminiAdapter implements LLMAdapter {
     onChunk: (chunk: string) => void,
   ): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    let lastError: unknown;
 
-    const genModel = this.client.getGenerativeModel({
-      model: modelName,
-      generationConfig: {
-        ...(temperature !== undefined && { temperature }),
-        ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
-      },
-    });
-    const result = await genModel.generateContentStream(prompt);
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
 
-    let fullText = '';
-    for await (const chunk of result.stream) {
-      const text = chunk.text();
-      if (text) {
-        onChunk(text);
-        fullText += text;
+      try {
+        const genModel = this.client.getGenerativeModel({
+          model: modelName,
+          generationConfig: {
+            ...(temperature !== undefined && { temperature }),
+            ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
+          },
+        });
+        const result = await genModel.generateContentStream(prompt);
+
+        let fullText = '';
+        for await (const chunk of result.stream) {
+          const text = chunk.text();
+          if (text) {
+            onChunk(text);
+            fullText += text;
+          }
+        }
+        return fullText;
+      } catch (error) {
+        lastError = error;
+        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+          break;
+        }
       }
     }
-    return fullText;
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new ExecutorError(
+      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      lastError,
+    );
   }
 }

--- a/src/executor/adapters/types.test.ts
+++ b/src/executor/adapters/types.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ExecutorError } from '../errors.js';
 
 // Mock adapters so createAdapter doesn't need a real API key
 vi.mock('./openai.js', () => ({
@@ -12,6 +11,14 @@ vi.mock('./openai.js', () => ({
 
 vi.mock('./anthropic.js', () => ({
   AnthropicAdapter: class MockAnthropicAdapter {
+    constructor(public readonly apiKey: string) {}
+    call = vi.fn();
+    callStreaming = vi.fn();
+  },
+}));
+
+vi.mock('./gemini.js', () => ({
+  GeminiAdapter: class MockGeminiAdapter {
     constructor(public readonly apiKey: string) {}
     call = vi.fn();
     callStreaming = vi.fn();
@@ -42,21 +49,17 @@ describe('createAdapter()', () => {
     expect(typeof adapter.callStreaming).toBe('function');
   });
 
+  it("returns an adapter with call() and callStreaming() for 'google'", async () => {
+    const { createAdapter } = await import('./types.js');
+    const adapter = createAdapter('google', 'test-key');
+    expect(typeof adapter.call).toBe('function');
+    expect(typeof adapter.callStreaming).toBe('function');
+  });
+
   it("returns an adapter with call() and callStreaming() for 'ollama'", async () => {
     const { createAdapter } = await import('./types.js');
     const adapter = createAdapter('ollama', 'http://localhost:11434/v1');
     expect(typeof adapter.call).toBe('function');
     expect(typeof adapter.callStreaming).toBe('function');
-  });
-
-  it("throws ExecutorError for 'google' (not yet supported)", async () => {
-    const { createAdapter } = await import('./types.js');
-    expect(() => createAdapter('google', 'key')).toThrow(ExecutorError);
-    expect(() => createAdapter('google', 'key')).toThrow(/not yet supported/);
-  });
-
-  it('error message for unsupported provider names the provider', async () => {
-    const { createAdapter } = await import('./types.js');
-    expect(() => createAdapter('google', 'key')).toThrow(/google/);
   });
 });

--- a/src/executor/adapters/types.ts
+++ b/src/executor/adapters/types.ts
@@ -1,6 +1,7 @@
 import type { ModelSpec, ProviderName } from '../../types/index.js';
 import { ExecutorError } from '../errors.js';
 import { AnthropicAdapter } from './anthropic.js';
+import { GeminiAdapter } from './gemini.js';
 import { OllamaAdapter } from './ollama.js';
 import { OpenAIAdapter } from './openai.js';
 
@@ -31,14 +32,12 @@ export function createAdapter(provider: ProviderName, apiKey: string): LLMAdapte
   switch (provider) {
     case 'openai':
       return new OpenAIAdapter(apiKey);
-    case 'ollama':
-      return new OllamaAdapter(apiKey); // apiKey is actually baseUrl for ollama
     case 'anthropic':
       return new AnthropicAdapter(apiKey);
     case 'google':
-      throw new ExecutorError(
-        `Provider '${provider}' is not yet supported. Only 'openai', 'anthropic', and 'ollama' are currently available.`,
-      );
+      return new GeminiAdapter(apiKey);
+    case 'ollama':
+      return new OllamaAdapter(apiKey); // apiKey is actually baseUrl for ollama
     default: {
       const _exhaustive: never = provider;
       throw new ExecutorError(`Unknown provider: ${String(_exhaustive)}`);


### PR DESCRIPTION
## Summary

Implements the Google Gemini provider adapter as specified in Issue #25.

## Changes
- `src/executor/adapters/gemini.ts`: GeminiAdapter implementing LLMAdapter
- `src/executor/adapters/gemini.test.ts`: Full unit tests with mocked SDK
- `src/executor/adapters/types.ts`: Register GeminiAdapter in createAdapter()
- `src/executor/adapters/types.test.ts`: Updated tests for google provider

## Testing
All existing tests pass. New tests cover: normal response, streaming, retry on 429/5xx/ECONNRESET, no-retry on 400.

Closes #25