### PR TITLE
docs: fix spec Ollama wording and add agent merge prohibition to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ CLI Layer → Parser → Renderer → Executor
 - ❌ Never add side effects (file I/O, network calls, randomness) to the Renderer.
 - ❌ Never create agent-specific config files (`CLAUDE.md`, `copilot-instructions.md`, `.claude/`, etc.).
 - ❌ Never bypass the `ValidatedCommand` interface between Parser and Renderer.
+- ❌ **Never merge a PR** — even with `--admin` or `--bypass-branch-protection`. Merging is a **human-only** action. Agents must stop after adding the `approved` label and wait for a human to add `LGTM` and merge.
 
 ---
 
@@ -110,6 +111,10 @@ Issues found?
 Both labels are required before merging:
 - `approved` — added automatically by Evaluator when all issues resolved
 - `LGTM` — added manually by a human maintainer
+
+> ⚠️ **Agents must STOP after adding the `approved` label.**
+> Executing `gh pr merge` (including `--admin` or `--bypass-branch-protection`) is **strictly forbidden** for agents.
+> Wait for a human to add `LGTM` and perform the merge.
 
 ### Becoming the Orchestrator
 

--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -268,7 +268,7 @@ Ollama does not use an API key. Instead, it requires a `base_url` pointing to th
 1. **Config file** — `ollama.base_url` in the yali config file
 2. **Default** — `http://localhost:11434/v1`
 
-> **Note:** Unlike other LLM providers, Ollama uses a `base_url` instead of an API key. Both are resolved exclusively from the config file — no environment variables are consulted.
+> **Note:** Unlike other LLM providers, Ollama uses a `base_url` instead of an API key. The `base_url` (like API keys for other providers) is resolved exclusively from the config file — no environment variables are consulted.
 
 ### Module Structure
 


### PR DESCRIPTION
## Summary

Two documentation fixes:

### 1. `docs/spec-draft.md` — Clarify ambiguous wording in Ollama Base URL Resolution

**Before** (ambiguous):
> Both are resolved exclusively from the config file — no environment variables are consulted.

"Both" was unclear (both what?).

**After** (explicit):
> The `base_url` (like API keys for other providers) is resolved exclusively from the config file — no environment variables are consulted.

### 2. `AGENTS.md` — Prohibit agents from merging PRs

Agents were using `gh pr merge --admin` to bypass branch protection, violating the Merge Gate policy. Two reinforcements added:

- **Do NOT Rules**: new explicit rule `❌ Never merge a PR — even with --admin. Merging is a human-only action.`
- **Merge Gate section**: warning block `⚠️ Agents must STOP after adding the approved label. gh pr merge is strictly forbidden for agents.`