### PR TITLE
feat: add API key format validation for all providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ CLI Layer → Parser → Renderer → Executor
 - ❌ Never add side effects (file I/O, network calls, randomness) to the Renderer.
 - ❌ Never create agent-specific config files (`CLAUDE.md`, `copilot-instructions.md`, `.claude/`, etc.).
 - ❌ Never bypass the `ValidatedCommand` interface between Parser and Renderer.
+- ❌ **Never merge a PR** — even with `--admin` or `--bypass-branch-protection`. Merging is a **human-only** action. Agents must stop after adding the `approved` label and wait for a human to add `LGTM` and merge.
 
 ---
 
@@ -110,6 +111,10 @@ Issues found?
 Both labels are required before merging:
 - `approved` — added automatically by Evaluator when all issues resolved
 - `LGTM` — added manually by a human maintainer
+
+> ⚠️ **Agents must STOP after adding the `approved` label.**
+> Executing `gh pr merge` (including `--admin` or `--bypass-branch-protection`) is **strictly forbidden** for agents.
+> Wait for a human to add `LGTM` and perform the merge.
 
 ### Becoming the Orchestrator
 

--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -224,6 +224,8 @@ yali config list                           # List all keys (masked)
 yali config unset openai.api_key           # Remove a key
 ```
 
+> **Note on `config set` validation:** When setting an API key for a provider whose format can be validated (OpenAI, Anthropic, Google), `config set` rejects keys that do not match the expected format and exits with code 1. Unrecognised providers (e.g., Ollama) bypass format validation and save the key as-is.
+
 ### Config File Location
 
 | OS | Path |
@@ -257,6 +259,7 @@ ollama:
 API keys are resolved **from the config file only**. Environment variables (`OPENAI_API_KEY`, etc.) are not consulted.
 
 - Key found in config file → used as-is
+- Key found but format is invalid → warning written to stderr, key is still used (non-blocking)
 - Key absent or config file missing → `ExecutorError` with `yali config set <provider>.api_key` guidance
 
 This is implemented in `src/executor/api-key-resolver.ts`, which reads from `src/config/store.ts`.
@@ -274,10 +277,11 @@ Ollama does not use an API key. Instead, it requires a `base_url` pointing to th
 
 ```
 src/config/
-  schema.ts    — zod schema for YaliConfig type
-  paths.ts     — OS-native config file path resolution
-  store.ts     — readConfig / writeConfig / getNestedValue / setNestedValue / unsetNestedValue
-  manager.ts   — handleConfigCommand: routes set/get/list/unset subcommands
+  schema.ts             — zod schema for YaliConfig type
+  paths.ts              — OS-native config file path resolution
+  store.ts              — readConfig / writeConfig / getNestedValue / setNestedValue / unsetNestedValue
+  manager.ts            — handleConfigCommand: routes set/get/list/unset subcommands
+  api-key-validator.ts  — format validation rules per provider
 ```
 
 ---

--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -268,7 +268,7 @@ Ollama does not use an API key. Instead, it requires a `base_url` pointing to th
 1. **Config file** — `ollama.base_url` in the yali config file
 2. **Default** — `http://localhost:11434/v1`
 
-> **Note:** Unlike other LLM providers, Ollama uses a `base_url` instead of an API key. Both are resolved exclusively from the config file — no environment variables are consulted.
+> **Note:** Unlike other LLM providers, Ollama uses a `base_url` instead of an API key. The `base_url` (like API keys for other providers) is resolved exclusively from the config file — no environment variables are consulted.
 
 ### Module Structure
 

--- a/src/config/api-key-validator.test.ts
+++ b/src/config/api-key-validator.test.ts
@@ -108,7 +108,7 @@ describe('validateApiKey() — google', () => {
 // Ollama
 // ---------------------------------------------------------------------------
 describe('validateApiKey() — ollama', () => {
-  it('accepts any non-empty arbitrary string', () => {
+  it('accepts any string, including empty', () => {
     expect(validateApiKey('ollama', 'anything-goes').valid).toBe(true);
     expect(validateApiKey('ollama', 'local-token-123').valid).toBe(true);
     expect(validateApiKey('ollama', 'short').valid).toBe(true);
@@ -116,6 +116,9 @@ describe('validateApiKey() — ollama', () => {
 
   it('accepts a key that would be invalid for other providers', () => {
     expect(validateApiKey('ollama', 'pk-wrong-prefix').valid).toBe(true);
+  });
+
+  it('accepts an empty string', () => {
     expect(validateApiKey('ollama', '').valid).toBe(true);
   });
 });

--- a/src/config/api-key-validator.test.ts
+++ b/src/config/api-key-validator.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { validateApiKey } from './api-key-validator.js';
+
+// ---------------------------------------------------------------------------
+// OpenAI
+// ---------------------------------------------------------------------------
+describe('validateApiKey() — openai', () => {
+  it('accepts a valid legacy sk- key', () => {
+    const result = validateApiKey('openai', 'sk-abcdefghijklmnopqrstuvwxyz12345678901234567890');
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a valid sk-proj- key', () => {
+    const result = validateApiKey('openai', 'sk-proj-abcdefghijklmnopqrstuvwxyz123456789');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a key without sk- prefix', () => {
+    const result = validateApiKey('openai', 'pk-abcdefghijklmnopqrstuvwxyz12345678');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/OpenAI/);
+    expect(result.error).toMatch(/sk-/);
+  });
+
+  it('rejects a key that is too short', () => {
+    const result = validateApiKey('openai', 'sk-tooshort');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Invalid OpenAI API key format/);
+  });
+
+  it('rejects an empty string', () => {
+    const result = validateApiKey('openai', '');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a key with invalid characters', () => {
+    const result = validateApiKey('openai', 'sk-invalid key with spaces!!!');
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anthropic
+// ---------------------------------------------------------------------------
+describe('validateApiKey() — anthropic', () => {
+  it('accepts a valid sk-ant- key', () => {
+    const result = validateApiKey(
+      'anthropic',
+      'sk-ant-api03-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz',
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a key without sk-ant- prefix', () => {
+    const result = validateApiKey('anthropic', 'sk-abcdefghijklmnopqrstuvwxyz12345678901234567');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Anthropic/);
+    expect(result.error).toMatch(/sk-ant-/);
+  });
+
+  it('rejects a key that is too short', () => {
+    const result = validateApiKey('anthropic', 'sk-ant-short');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Invalid Anthropic API key format/);
+  });
+
+  it('rejects an empty string', () => {
+    const result = validateApiKey('anthropic', '');
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google
+// ---------------------------------------------------------------------------
+describe('validateApiKey() — google', () => {
+  it('accepts a valid AIza key of exactly 39 chars', () => {
+    // AIza + 35 chars = 39 total
+    const result = validateApiKey('google', 'AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a key without AIza prefix', () => {
+    const result = validateApiKey('google', 'BIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Google/);
+    expect(result.error).toMatch(/AIza/);
+  });
+
+  it('rejects a key that is too short (less than 39 chars)', () => {
+    const result = validateApiKey('google', 'AIzaShort');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Invalid Google API key format/);
+  });
+
+  it('rejects a key that is too long (more than 39 chars)', () => {
+    const result = validateApiKey('google', 'AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6QEXTRA');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    const result = validateApiKey('google', '');
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ollama
+// ---------------------------------------------------------------------------
+describe('validateApiKey() — ollama', () => {
+  it('accepts any non-empty arbitrary string', () => {
+    expect(validateApiKey('ollama', 'anything-goes').valid).toBe(true);
+    expect(validateApiKey('ollama', 'local-token-123').valid).toBe(true);
+    expect(validateApiKey('ollama', 'short').valid).toBe(true);
+  });
+
+  it('accepts a key that would be invalid for other providers', () => {
+    expect(validateApiKey('ollama', 'pk-wrong-prefix').valid).toBe(true);
+    expect(validateApiKey('ollama', '').valid).toBe(true);
+  });
+});

--- a/src/config/api-key-validator.ts
+++ b/src/config/api-key-validator.ts
@@ -1,0 +1,63 @@
+import type { ProviderName } from '../types/index.js';
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/** Human-readable display names used in error messages. */
+const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderName, string>> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  google: 'Google',
+};
+
+/**
+ * Per-provider API key validation rules.
+ * Each rule specifies a regex pattern and a human-readable description
+ * of the expected format for error messages.
+ */
+const PROVIDER_RULES: Partial<Record<ProviderName, { pattern: RegExp; description: string }>> = {
+  openai: {
+    pattern: /^sk-[A-Za-z0-9\-_]{20,}$/,
+    description: 'must start with "sk-" and be at least 23 characters (e.g. sk-...)',
+  },
+  anthropic: {
+    pattern: /^sk-ant-[A-Za-z0-9\-_]{10,}$/,
+    description: 'must start with "sk-ant-" and be at least 17 characters (e.g. sk-ant-api03-...)',
+  },
+  google: {
+    pattern: /^AIza[A-Za-z0-9\-_]{35}$/,
+    description: 'must start with "AIza" and be exactly 39 characters',
+  },
+};
+
+/**
+ * Validates an API key for the given provider against known format rules.
+ *
+ * - OpenAI: must start with "sk-", min 23 chars total
+ * - Anthropic: must start with "sk-ant-", min 17 chars total
+ * - Google: must start with "AIza", exactly 39 chars
+ * - Ollama: any string is accepted (no validation — local LLM, no real API key needed)
+ *
+ * @returns `{ valid: true }` if the key matches the expected format,
+ *          `{ valid: false, error: string }` otherwise.
+ */
+export function validateApiKey(provider: ProviderName, key: string): ValidationResult {
+  const rule = PROVIDER_RULES[provider];
+
+  if (!rule) {
+    // No rule defined (e.g. Ollama) → accept any non-empty string
+    return { valid: true };
+  }
+
+  if (!rule.pattern.test(key)) {
+    const providerLabel = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+    return {
+      valid: false,
+      error: `Invalid ${providerLabel} API key format: ${rule.description}.`,
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/config/manager.test.ts
+++ b/src/config/manager.test.ts
@@ -196,24 +196,52 @@ describe('handleConfigCommand set — API key format validation', () => {
     expect(config.openai?.api_key).toBe('sk-abcdefghijklmnopqrst');
   });
 
-  it('exits with code 1 for an invalid Anthropic key', async () => {
+  it('exits with code 1 and writes to stderr for an invalid Anthropic key', async () => {
     const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit called');
+    });
+    const stderrOutput: string[] = [];
+    const stderrMock = vi.spyOn(process.stderr, 'write').mockImplementation((data: string | Uint8Array) => {
+      stderrOutput.push(String(data));
+      return true;
     });
     await expect(
       handleConfigCommand(['set', 'anthropic.api_key', 'invalid-anthropic-key'], configPath),
     ).rejects.toThrow('process.exit called');
+    expect(stderrOutput.join('')).toContain('❌');
     exitMock.mockRestore();
+    stderrMock.mockRestore();
   });
 
-  it('exits with code 1 for an invalid Google key', async () => {
+  it('does NOT exit and saves successfully for a valid Anthropic key', async () => {
+    const { readConfig } = await import('./store.js');
+    await handleConfigCommand(['set', 'anthropic.api_key', 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456789012'], configPath);
+    const config = readConfig(configPath);
+    expect(config.anthropic?.api_key).toBe('sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456789012');
+  });
+
+  it('exits with code 1 and writes to stderr for an invalid Google key', async () => {
     const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit called');
+    });
+    const stderrOutput: string[] = [];
+    const stderrMock = vi.spyOn(process.stderr, 'write').mockImplementation((data: string | Uint8Array) => {
+      stderrOutput.push(String(data));
+      return true;
     });
     await expect(
       handleConfigCommand(['set', 'google.api_key', 'not-a-google-key'], configPath),
     ).rejects.toThrow('process.exit called');
+    expect(stderrOutput.join('')).toContain('❌');
     exitMock.mockRestore();
+    stderrMock.mockRestore();
+  });
+
+  it('does NOT exit and saves successfully for a valid Google key', async () => {
+    const { readConfig } = await import('./store.js');
+    await handleConfigCommand(['set', 'google.api_key', 'AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q'], configPath);
+    const config = readConfig(configPath);
+    expect(config.google?.api_key).toBe('AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q');
   });
 
   it('does NOT exit for an Ollama arbitrary key (no validation)', async () => {

--- a/src/config/manager.test.ts
+++ b/src/config/manager.test.ts
@@ -39,9 +39,9 @@ describe('handleConfigCommand set', () => {
     // Temporarily override getConfigPath via env
     const { readConfig } = await import('./store.js');
     // We test by directly using configPath
-    await handleConfigCommand(['set', 'openai.api_key', 'sk-test'], configPath);
+    await handleConfigCommand(['set', 'openai.api_key', 'sk-abcdefghijklmnopqrst'], configPath);
     const config = readConfig(configPath);
-    expect(config.openai?.api_key).toBe('sk-test');
+    expect(config.openai?.api_key).toBe('sk-abcdefghijklmnopqrst');
   });
 
   it('exits with code 1 if value argument is missing', async () => {
@@ -154,7 +154,7 @@ describe('handleConfigCommand unset', () => {
 });
 
 // ---------------------------------------------------------------------------
-// handleConfigCommand — unknown subcommand
+// handleConfigCommand unknown subcommand
 // ---------------------------------------------------------------------------
 describe('handleConfigCommand unknown subcommand', () => {
   it('exits with code 1 and usage error', async () => {
@@ -165,5 +165,61 @@ describe('handleConfigCommand unknown subcommand', () => {
       handleConfigCommand(['unknown'], configPath),
     ).rejects.toThrow('process.exit called');
     exitMock.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConfigCommand set — API key format validation
+// ---------------------------------------------------------------------------
+describe('handleConfigCommand set — API key format validation', () => {
+  it('exits with code 1 and writes to stderr for invalid OpenAI key (missing sk- prefix)', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    const stderrOutput: string[] = [];
+    const stderrMock = vi.spyOn(process.stderr, 'write').mockImplementation((data: string | Uint8Array) => {
+      stderrOutput.push(String(data));
+      return true;
+    });
+    await expect(
+      handleConfigCommand(['set', 'openai.api_key', 'invalid-key-without-prefix'], configPath),
+    ).rejects.toThrow('process.exit called');
+    expect(stderrOutput.join('')).toContain('❌');
+    exitMock.mockRestore();
+    stderrMock.mockRestore();
+  });
+
+  it('does NOT exit and saves successfully for a valid OpenAI key', async () => {
+    const { readConfig } = await import('./store.js');
+    await handleConfigCommand(['set', 'openai.api_key', 'sk-abcdefghijklmnopqrst'], configPath);
+    const config = readConfig(configPath);
+    expect(config.openai?.api_key).toBe('sk-abcdefghijklmnopqrst');
+  });
+
+  it('exits with code 1 for an invalid Anthropic key', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(
+      handleConfigCommand(['set', 'anthropic.api_key', 'invalid-anthropic-key'], configPath),
+    ).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
+
+  it('exits with code 1 for an invalid Google key', async () => {
+    const exitMock = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    await expect(
+      handleConfigCommand(['set', 'google.api_key', 'not-a-google-key'], configPath),
+    ).rejects.toThrow('process.exit called');
+    exitMock.mockRestore();
+  });
+
+  it('does NOT exit for an Ollama arbitrary key (no validation)', async () => {
+    const { readConfig } = await import('./store.js');
+    await handleConfigCommand(['set', 'ollama.api_key', 'any-arbitrary-value'], configPath);
+    const config = readConfig(configPath);
+    expect(config.ollama?.api_key).toBe('any-arbitrary-value');
   });
 });

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1,4 +1,6 @@
+import type { ProviderName } from '../types/index.js';
 import { getConfigPath } from './paths.js';
+import { validateApiKey } from './api-key-validator.js';
 import {
   readConfig,
   writeConfig,
@@ -7,6 +9,8 @@ import {
   unsetNestedValue,
   ConfigError,
 } from './store.js';
+
+const KNOWN_PROVIDERS = new Set<ProviderName>(['openai', 'anthropic', 'google', 'ollama']);
 
 /** Masks an API key for safe display: sk-***...xxxx */
 export function maskApiKey(value: string): string {
@@ -38,6 +42,19 @@ export async function handleConfigCommand(
         process.stderr.write('Example: yali config set openai.api_key sk-...\n');
         process.exit(1);
       }
+
+      const keyParts = key.split('.');
+      if (keyParts.length === 2 && keyParts[1] === 'api_key') {
+        const provider = keyParts[0] as ProviderName;
+        if (KNOWN_PROVIDERS.has(provider)) {
+          const result = validateApiKey(provider, value);
+          if (!result.valid) {
+            process.stderr.write(`❌ ${result.error}\n`);
+            process.exit(1);
+          }
+        }
+      }
+
       try {
         const config = readConfig(configPath);
         const updated = setNestedValue(config, key, value);

--- a/src/executor/api-key-resolver.test.ts
+++ b/src/executor/api-key-resolver.test.ts
@@ -76,4 +76,33 @@ describe('resolveApiKey()', () => {
   });
 });
 
+describe('resolveApiKey() — format validation warnings', () => {
+  it('returns the key even when format is invalid', () => {
+    writeConfig(configPath, { openai: { api_key: 'invalid-key' } });
+    expect(resolveApiKey('openai')).toBe('invalid-key');
+  });
 
+  it('writes a warning to stderr when the key has an invalid format', () => {
+    writeConfig(configPath, { openai: { api_key: 'invalid-key' } });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      resolveApiKey('openai');
+      const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((msg) => msg.includes('⚠ Warning:'))).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does NOT write a warning to stderr when the key has a valid format', () => {
+    writeConfig(configPath, { openai: { api_key: 'sk-validkeyabcdefghijklmno' } });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      resolveApiKey('openai');
+      const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((msg) => msg.includes('⚠ Warning:'))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/src/executor/api-key-resolver.test.ts
+++ b/src/executor/api-key-resolver.test.ts
@@ -94,6 +94,18 @@ describe('resolveApiKey() — format validation warnings', () => {
     }
   });
 
+  it('writes a warning to stderr for an invalid Anthropic key', () => {
+    writeConfig(configPath, { anthropic: { api_key: 'invalid-anthropic-key' } });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      resolveApiKey('anthropic');
+      const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((msg) => msg.includes('⚠ Warning:'))).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('does NOT write a warning to stderr when the key has a valid format', () => {
     writeConfig(configPath, { openai: { api_key: 'sk-validkeyabcdefghijklmno' } });
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);

--- a/src/executor/api-key-resolver.ts
+++ b/src/executor/api-key-resolver.ts
@@ -2,6 +2,7 @@ import type { ProviderName } from '../types/index.js';
 import { ExecutorError } from './errors.js';
 import { getConfigPath } from '../config/paths.js';
 import { readConfig, getNestedValue } from '../config/store.js';
+import { validateApiKey } from '../config/api-key-validator.js';
 
 /** Human-readable display names for each provider. */
 const PROVIDER_LABELS: Record<ProviderName, string> = {
@@ -31,6 +32,10 @@ export function resolveApiKey(provider: ProviderName): string {
   }
 
   if (apiKey) {
+    const validation = validateApiKey(provider, apiKey);
+    if (!validation.valid) {
+      process.stderr.write(`⚠ Warning: ${validation.error}\n`);
+    }
     return apiKey;
   }
 


### PR DESCRIPTION
## Summary

Validates API key format for OpenAI, Anthropic, Google and Ollama when:
- `yali config set <provider>.api_key <value>` is called (blocks invalid format)
- API key is resolved at execution time (warns but does not block)

## Changes

### `src/config/api-key-validator.ts` (new)
- Pure-function `validateApiKey(provider, key): ValidationResult`
- OpenAI: `sk-` prefix required, min 23 chars
- Anthropic: `sk-ant-` prefix required, min 17 chars
- Google: `AIza` prefix required, exactly 39 chars
- Ollama: any string accepted (local LLM, no API key needed)

### `src/config/api-key-validator.test.ts` (new)
- 17 tests covering all providers — normal and error cases

### `src/config/manager.ts`
- In `case 'set':`, detect `<provider>.api_key` pattern and call `validateApiKey`
- On failure: write `❌ <error>` to stderr and `process.exit(1)` (save blocked)

### `src/config/manager.test.ts`
- 5 new tests for format validation in config set

### `src/executor/api-key-resolver.ts`
- After resolving key, call `validateApiKey` and write `⚠ Warning:` to stderr if invalid
- Execution is never blocked (handles manually-edited config files gracefully)

### `src/executor/api-key-resolver.test.ts`
- 3 new tests: invalid key returns value, warns to stderr; valid key produces no warning

Closes #32