### PR TITLE
feat: add configurable timeout and max_retries to ModelSpec (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ Output:
 
 ---
 
+## Cost & Rate Limit Protection
+
+yali includes built-in safeguards to prevent runaway API usage:
+
+- **Timeout** — Each API call is cancelled after **60 seconds** by default. Override per command:
+  ```yaml
+  model:
+    name: gpt-4o
+    timeout_ms: 30000   # 30 seconds
+  ```
+- **Retry limit** — Retryable errors (rate limits, server errors) are retried up to **3 times** with exponential backoff. Override per command:
+  ```yaml
+  model:
+    name: gpt-4o
+    max_retries: 1   # retry at most once
+  ```
+
+> **⚠️ Cost warning:** Even with these defaults, repeated or parallel invocations of `yali run` can accumulate LLM API charges quickly. Monitor your provider usage dashboards and set appropriate limits in your YAML files for long-running workflows.
+
+---
+
 ## Documentation
 
 Full usage guide, YAML schema reference, and advanced examples:

--- a/docs/spec-draft.md
+++ b/docs/spec-draft.md
@@ -371,6 +371,8 @@ ModelSpec {
   provider?:    ProviderName    # defaults to 'openai' when omitted; resolved by the Parser
   temperature?: float
   max_tokens?:  int
+  timeout_ms?:  int             # API call timeout in milliseconds; defaults to 60000 (60s)
+  max_retries?: int             # maximum retry attempts on retryable errors; defaults to 3
 }
 ```
 

--- a/src/executor/adapters/anthropic.test.ts
+++ b/src/executor/adapters/anthropic.test.ts
@@ -285,4 +285,63 @@ describe('AnthropicAdapter', () => {
     expect(caughtError).toBeInstanceOf(ExecutorError);
     expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
   });
+
+  // callStreaming() — max_retries を指定した回数でリトライを止める
+  it('callStreaming() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const anthropicModule = (await import('@anthropic-ai/sdk')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = anthropicModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'claude-3-5-sonnet-20241022', max_retries: 1 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  // call() — max_retries: 0 は即座に失敗（リトライなし）
+  it('call() makes exactly 1 attempt when max_retries is 0', async () => {
+    const anthropicModule = (await import('@anthropic-ai/sdk')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = anthropicModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(
+      adapter.call('prompt', { name: 'claude-3-5-sonnet-20241022', max_retries: 0 }),
+    ).rejects.toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — タイムアウトはリトライされない（mockCreate は1回だけ呼ばれる）
+  it('call() does not retry when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'claude-3-5-sonnet-20241022', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1); // no retry on timeout
+  });
 });

--- a/src/executor/adapters/anthropic.test.ts
+++ b/src/executor/adapters/anthropic.test.ts
@@ -220,4 +220,69 @@ describe('AnthropicAdapter', () => {
     expect(mockCreate).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
     vi.useRealTimers();
   });
+
+  // call() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('call() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'claude-3-5-sonnet-20241022', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // callStreaming() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('callStreaming() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    async function* neverGen() {
+      yield { type: 'content_block_delta', delta: { type: 'text_delta', text: '' } };
+      await new Promise<never>(() => {});
+    }
+    mockCreate.mockResolvedValue(neverGen());
+
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'claude-3-5-sonnet-20241022', timeout_ms: 5000 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // call() — max_retries を指定した回数でリトライを止める
+  it('call() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const anthropicModule = (await import('@anthropic-ai/sdk')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = anthropicModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new AnthropicAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'claude-3-5-sonnet-20241022', max_retries: 1 })
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
 });

--- a/src/executor/adapters/anthropic.ts
+++ b/src/executor/adapters/anthropic.ts
@@ -4,7 +4,8 @@ import { ExecutorError } from '../errors.js';
 import type { LLMAdapter } from './types.js';
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const BASE_DELAY_MS = 1000;
 
 function isRetryable(error: unknown): boolean {
@@ -22,6 +23,17 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 export class AnthropicAdapter implements LLMAdapter {
   private readonly client: Anthropic;
 
@@ -31,25 +43,28 @@ export class AnthropicAdapter implements LLMAdapter {
 
   async call(prompt: string, model: ModelSpec): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const response = await this.client.messages.create({
+        const apiCall = this.client.messages.create({
           model: modelName,
           max_tokens: max_tokens ?? 1024,
           messages: [{ role: 'user', content: prompt }],
           ...(temperature !== undefined && { temperature }),
         });
 
+        const response = await withTimeout(apiCall, timeoutMs, 'LLM API call');
         return (response.content[0] as { type: string; text?: string })?.text ?? '';
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -58,7 +73,7 @@ export class AnthropicAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }
@@ -69,36 +84,42 @@ export class AnthropicAdapter implements LLMAdapter {
     onChunk: (chunk: string) => void,
   ): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const stream = await this.client.messages.create({
-          model: modelName,
-          max_tokens: max_tokens ?? 1024,
-          messages: [{ role: 'user', content: prompt }],
-          stream: true,
-          ...(temperature !== undefined && { temperature }),
-        });
+        const streamingCall = (async () => {
+          const stream = await this.client.messages.create({
+            model: modelName,
+            max_tokens: max_tokens ?? 1024,
+            messages: [{ role: 'user', content: prompt }],
+            stream: true,
+            ...(temperature !== undefined && { temperature }),
+          });
 
-        let fullText = '';
-        for await (const event of stream) {
-          if (
-            event.type === 'content_block_delta' &&
-            event.delta.type === 'text_delta'
-          ) {
-            onChunk(event.delta.text);
-            fullText += event.delta.text;
+          let fullText = '';
+          for await (const event of stream) {
+            if (
+              event.type === 'content_block_delta' &&
+              event.delta.type === 'text_delta'
+            ) {
+              onChunk(event.delta.text);
+              fullText += event.delta.text;
+            }
           }
-        }
-        return fullText;
+          return fullText;
+        })();
+
+        return await withTimeout(streamingCall, timeoutMs, 'LLM API streaming call');
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -107,7 +128,7 @@ export class AnthropicAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API streaming call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }

--- a/src/executor/adapters/gemini.test.ts
+++ b/src/executor/adapters/gemini.test.ts
@@ -286,4 +286,57 @@ describe('GeminiAdapter', () => {
     expect(caughtError).toBeInstanceOf(ExecutorError);
     expect(mockGenerateContent).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
   });
+
+  // callStreaming() — max_retries を指定した回数でリトライを止める
+  it('callStreaming() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContentStream.mockRejectedValue(rateLimitError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'gemini-1.5-flash', max_retries: 1 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  // call() — max_retries: 0 は即座に失敗（リトライなし）
+  it('call() makes exactly 1 attempt when max_retries is 0', async () => {
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContent.mockRejectedValue(rateLimitError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(
+      adapter.call('prompt', { name: 'gemini-1.5-flash', max_retries: 0 }),
+    ).rejects.toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — タイムアウトはリトライされない（mockGenerateContent は1回だけ呼ばれる）
+  it('call() does not retry when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockGenerateContent.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gemini-1.5-flash', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1); // no retry on timeout
+  });
 });

--- a/src/executor/adapters/gemini.test.ts
+++ b/src/executor/adapters/gemini.test.ts
@@ -224,4 +224,66 @@ describe('GeminiAdapter', () => {
     expect(mockGenerateContentStream).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
     vi.useRealTimers();
   });
+
+  // call() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('call() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockGenerateContent.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gemini-1.5-flash', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // callStreaming() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('callStreaming() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    async function* neverStream() {
+      await new Promise<never>(() => {});
+      yield { text: () => '' };
+    }
+    mockGenerateContentStream.mockResolvedValue({ stream: neverStream() });
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'gemini-1.5-flash', timeout_ms: 5000 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // call() — max_retries を指定した回数でリトライを止める
+  it('call() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const rateLimitError = Object.assign(new Error('rate limit'), { status: 429 });
+    mockGenerateContent.mockRejectedValue(rateLimitError);
+
+    const adapter = new GeminiAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gemini-1.5-flash', max_retries: 1 })
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
 });

--- a/src/executor/adapters/gemini.ts
+++ b/src/executor/adapters/gemini.ts
@@ -4,7 +4,8 @@ import { ExecutorError } from '../errors.js';
 import type { LLMAdapter } from './types.js';
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const BASE_DELAY_MS = 1000;
 
 function isRetryable(error: unknown): boolean {
@@ -25,6 +26,17 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 export class GeminiAdapter implements LLMAdapter {
   private readonly client: GoogleGenerativeAI;
 
@@ -34,9 +46,11 @@ export class GeminiAdapter implements LLMAdapter {
 
   async call(prompt: string, model: ModelSpec): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
@@ -49,11 +63,12 @@ export class GeminiAdapter implements LLMAdapter {
             ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
           },
         });
-        const result = await genModel.generateContent(prompt);
+        const apiCall = genModel.generateContent(prompt);
+        const result = await withTimeout(apiCall, timeoutMs, 'LLM API call');
         return result.response.text();
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -62,7 +77,7 @@ export class GeminiAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }
@@ -73,35 +88,41 @@ export class GeminiAdapter implements LLMAdapter {
     onChunk: (chunk: string) => void,
   ): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const genModel = this.client.getGenerativeModel({
-          model: modelName,
-          generationConfig: {
-            ...(temperature !== undefined && { temperature }),
-            ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
-          },
-        });
-        const result = await genModel.generateContentStream(prompt);
+        const streamingCall = (async () => {
+          const genModel = this.client.getGenerativeModel({
+            model: modelName,
+            generationConfig: {
+              ...(temperature !== undefined && { temperature }),
+              ...(max_tokens !== undefined && { maxOutputTokens: max_tokens }),
+            },
+          });
+          const result = await genModel.generateContentStream(prompt);
 
-        let fullText = '';
-        for await (const chunk of result.stream) {
-          const text = chunk.text();
-          if (text) {
-            onChunk(text);
-            fullText += text;
+          let fullText = '';
+          for await (const chunk of result.stream) {
+            const text = chunk.text();
+            if (text) {
+              onChunk(text);
+              fullText += text;
+            }
           }
-        }
-        return fullText;
+          return fullText;
+        })();
+
+        return await withTimeout(streamingCall, timeoutMs, 'LLM API streaming call');
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -110,7 +131,7 @@ export class GeminiAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API streaming call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }

--- a/src/executor/adapters/ollama.test.ts
+++ b/src/executor/adapters/ollama.test.ts
@@ -290,4 +290,69 @@ describe('OllamaAdapter', () => {
     ).rejects.toBeInstanceOf(ExecutorError);
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
+
+  // call() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('call() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'llama3.2', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // callStreaming() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('callStreaming() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    async function* neverGen() {
+      await new Promise<never>(() => {});
+      yield { choices: [{ delta: { content: '' } }] };
+    }
+    mockCreate.mockResolvedValue(neverGen());
+
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'llama3.2', timeout_ms: 5000 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // call() — max_retries を指定した回数でリトライを止める
+  it('call() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'llama3.2', max_retries: 1 })
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
 });

--- a/src/executor/adapters/ollama.test.ts
+++ b/src/executor/adapters/ollama.test.ts
@@ -355,4 +355,63 @@ describe('OllamaAdapter', () => {
     expect(caughtError).toBeInstanceOf(ExecutorError);
     expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
   });
+
+  // callStreaming() — max_retries を指定した回数でリトライを止める
+  it('callStreaming() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'llama3.2', max_retries: 1 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  // call() — max_retries: 0 は即座に失敗（リトライなし）
+  it('call() makes exactly 1 attempt when max_retries is 0', async () => {
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(
+      adapter.call('prompt', { name: 'llama3.2', max_retries: 0 }),
+    ).rejects.toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — タイムアウトはリトライされない（mockCreate は1回だけ呼ばれる）
+  it('call() does not retry when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new OllamaAdapter();
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'llama3.2', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1); // no retry on timeout
+  });
 });

--- a/src/executor/adapters/ollama.ts
+++ b/src/executor/adapters/ollama.ts
@@ -4,7 +4,8 @@ import { ExecutorError } from '../errors.js';
 import type { LLMAdapter } from './types.js';
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const BASE_DELAY_MS = 1000;
 
 export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1';
@@ -31,6 +32,17 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 export class OllamaAdapter implements LLMAdapter {
   private readonly client: OpenAI;
 
@@ -40,21 +52,24 @@ export class OllamaAdapter implements LLMAdapter {
 
   async call(prompt: string, model: ModelSpec): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const response = await this.client.chat.completions.create({
+        const apiCall = this.client.chat.completions.create({
           model: modelName,
           messages: [{ role: 'user', content: prompt }],
           ...(temperature !== undefined && { temperature }),
           ...(max_tokens !== undefined && { max_tokens }),
         });
 
+        const response = await withTimeout(apiCall, timeoutMs, 'LLM API call');
         return response.choices[0]?.message?.content ?? '';
       } catch (error) {
         if (isOllamaNotRunning(error)) {
@@ -64,7 +79,7 @@ export class OllamaAdapter implements LLMAdapter {
           );
         }
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -72,7 +87,7 @@ export class OllamaAdapter implements LLMAdapter {
 
     const message = lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }
@@ -83,31 +98,37 @@ export class OllamaAdapter implements LLMAdapter {
     onChunk: (chunk: string) => void,
   ): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const stream = await this.client.chat.completions.create({
-          model: modelName,
-          messages: [{ role: 'user', content: prompt }],
-          stream: true,
-          ...(temperature !== undefined && { temperature }),
-          ...(max_tokens !== undefined && { max_tokens }),
-        });
+        const streamingCall = (async () => {
+          const stream = await this.client.chat.completions.create({
+            model: modelName,
+            messages: [{ role: 'user', content: prompt }],
+            stream: true,
+            ...(temperature !== undefined && { temperature }),
+            ...(max_tokens !== undefined && { max_tokens }),
+          });
 
-        let fullText = '';
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content ?? '';
-          if (delta) {
-            onChunk(delta);
-            fullText += delta;
+          let fullText = '';
+          for await (const chunk of stream) {
+            const delta = chunk.choices[0]?.delta?.content ?? '';
+            if (delta) {
+              onChunk(delta);
+              fullText += delta;
+            }
           }
-        }
-        return fullText;
+          return fullText;
+        })();
+
+        return await withTimeout(streamingCall, timeoutMs, 'LLM API streaming call');
       } catch (error) {
         if (isOllamaNotRunning(error)) {
           throw new ExecutorError(
@@ -116,7 +137,7 @@ export class OllamaAdapter implements LLMAdapter {
           );
         }
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -124,7 +145,7 @@ export class OllamaAdapter implements LLMAdapter {
 
     const message = lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API streaming call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }

--- a/src/executor/adapters/openai.test.ts
+++ b/src/executor/adapters/openai.test.ts
@@ -174,4 +174,69 @@ describe('OpenAIAdapter', () => {
     const result = await adapter.callStreaming('prompt', { name: 'gpt-4o-mini' }, () => {});
     expect(result).toBe('Hello world!');
   });
+
+  // call() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('call() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gpt-4o-mini', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // callStreaming() — timeout_ms を超えた場合 ExecutorError をスロー
+  it('callStreaming() throws ExecutorError when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    async function* neverGen() {
+      await new Promise<never>(() => {});
+      yield { choices: [{ delta: { content: '' } }] };
+    }
+    mockCreate.mockResolvedValue(neverGen());
+
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'gpt-4o-mini', timeout_ms: 5000 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect((caughtError as Error).message).toContain('timed out');
+  });
+
+  // call() — max_retries を指定した回数でリトライを止める
+  it('call() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gpt-4o-mini', max_retries: 1 })
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
 });

--- a/src/executor/adapters/openai.test.ts
+++ b/src/executor/adapters/openai.test.ts
@@ -239,4 +239,63 @@ describe('OpenAIAdapter', () => {
     expect(caughtError).toBeInstanceOf(ExecutorError);
     expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
   });
+
+  // callStreaming() — max_retries を指定した回数でリトライを止める
+  it('callStreaming() respects custom max_retries', async () => {
+    vi.useFakeTimers();
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .callStreaming('prompt', { name: 'gpt-4o-mini', max_retries: 1 }, () => {})
+      .catch((e) => { caughtError = e; });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  // call() — max_retries: 0 は即座に失敗（リトライなし）
+  it('call() makes exactly 1 attempt when max_retries is 0', async () => {
+    const openaiModule = (await import('openai')) as unknown as {
+      default: { APIError: new (msg: string, status: number) => Error };
+    };
+    const APIError = openaiModule.default.APIError;
+
+    mockCreate.mockRejectedValue(new APIError('rate limit', 429));
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    await expect(
+      adapter.call('prompt', { name: 'gpt-4o-mini', max_retries: 0 }),
+    ).rejects.toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  // call() — タイムアウトはリトライされない（mockCreate は1回だけ呼ばれる）
+  it('call() does not retry when timeout_ms is exceeded', async () => {
+    vi.useFakeTimers();
+    mockCreate.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const adapter = new OpenAIAdapter('test-key');
+    const { ExecutorError } = await import('../errors.js');
+
+    let caughtError: unknown;
+    const settled = adapter
+      .call('prompt', { name: 'gpt-4o-mini', timeout_ms: 5000 })
+      .catch((e) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(5001);
+    await settled;
+
+    expect(caughtError).toBeInstanceOf(ExecutorError);
+    expect(mockCreate).toHaveBeenCalledTimes(1); // no retry on timeout
+  });
 });

--- a/src/executor/adapters/openai.ts
+++ b/src/executor/adapters/openai.ts
@@ -4,7 +4,8 @@ import { ExecutorError } from '../errors.js';
 import type { LLMAdapter } from './types.js';
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const BASE_DELAY_MS = 1000;
 
 function isRetryable(error: unknown): boolean {
@@ -22,6 +23,17 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 export class OpenAIAdapter implements LLMAdapter {
   private readonly client: OpenAI;
 
@@ -31,25 +43,28 @@ export class OpenAIAdapter implements LLMAdapter {
 
   async call(prompt: string, model: ModelSpec): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const response = await this.client.chat.completions.create({
+        const apiCall = this.client.chat.completions.create({
           model: modelName,
           messages: [{ role: 'user', content: prompt }],
           ...(temperature !== undefined && { temperature }),
           ...(max_tokens !== undefined && { max_tokens }),
         });
 
+        const response = await withTimeout(apiCall, timeoutMs, 'LLM API call');
         return response.choices[0]?.message?.content ?? '';
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -58,7 +73,7 @@ export class OpenAIAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }
@@ -69,34 +84,40 @@ export class OpenAIAdapter implements LLMAdapter {
     onChunk: (chunk: string) => void,
   ): Promise<string> {
     const { name: modelName, temperature, max_tokens } = model;
+    const maxRetries = model.max_retries ?? DEFAULT_MAX_RETRIES;
+    const timeoutMs = model.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
       }
 
       try {
-        const stream = await this.client.chat.completions.create({
-          model: modelName,
-          messages: [{ role: 'user', content: prompt }],
-          stream: true,
-          ...(temperature !== undefined && { temperature }),
-          ...(max_tokens !== undefined && { max_tokens }),
-        });
+        const streamingCall = (async () => {
+          const stream = await this.client.chat.completions.create({
+            model: modelName,
+            messages: [{ role: 'user', content: prompt }],
+            stream: true,
+            ...(temperature !== undefined && { temperature }),
+            ...(max_tokens !== undefined && { max_tokens }),
+          });
 
-        let fullText = '';
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content ?? '';
-          if (delta) {
-            onChunk(delta);
-            fullText += delta;
+          let fullText = '';
+          for await (const chunk of stream) {
+            const delta = chunk.choices[0]?.delta?.content ?? '';
+            if (delta) {
+              onChunk(delta);
+              fullText += delta;
+            }
           }
-        }
-        return fullText;
+          return fullText;
+        })();
+
+        return await withTimeout(streamingCall, timeoutMs, 'LLM API streaming call');
       } catch (error) {
         lastError = error;
-        if (!isRetryable(error) || attempt === MAX_RETRIES) {
+        if (!isRetryable(error) || attempt === maxRetries) {
           break;
         }
       }
@@ -105,7 +126,7 @@ export class OpenAIAdapter implements LLMAdapter {
     const message =
       lastError instanceof Error ? lastError.message : String(lastError);
     throw new ExecutorError(
-      `LLM API streaming call failed after ${MAX_RETRIES} retries: ${message}`,
+      `LLM API streaming call failed after ${maxRetries} retries: ${message}`,
       lastError,
     );
   }

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -43,6 +43,23 @@ describe('ValidatedCommandSchema — normalization', () => {
     });
   });
 
+  it('passes timeout_ms and max_retries through to ValidatedCommand', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hi',
+      model: { name: 'gpt-4o', timeout_ms: 30000, max_retries: 1 },
+    });
+    expect(result.steps[0].model.timeout_ms).toBe(30000);
+    expect(result.steps[0].model.max_retries).toBe(1);
+  });
+
+  it('accepts max_retries: 0 (no retries)', () => {
+    const result = ValidatedCommandSchema.parse({
+      prompt: 'Hi',
+      model: { name: 'gpt-4o', max_retries: 0 },
+    });
+    expect(result.steps[0].model.max_retries).toBe(0);
+  });
+
   it('defaults input_spec to stdin when input key is absent', () => {
     const result = ValidatedCommandSchema.parse({ prompt: 'Hi', model: 'gpt-4o' });
     expect(result.input_spec).toEqual({ from: 'stdin', var: 'input' });
@@ -191,6 +208,38 @@ describe('ValidatedCommandSchema — validation errors', () => {
         steps: [{ id: 's1', prompt: 'Bad\x00byte', model: 'gpt-4o' }],
       }),
     ).toThrow(/NUL bytes/);
+  });
+
+  // timeout_ms validation
+  it('throws when timeout_ms is 0 (not positive)', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({ prompt: 'Hi', model: { name: 'gpt-4o', timeout_ms: 0 } }),
+    ).toThrow();
+  });
+
+  it('throws when timeout_ms is negative', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({ prompt: 'Hi', model: { name: 'gpt-4o', timeout_ms: -1 } }),
+    ).toThrow();
+  });
+
+  it('throws when timeout_ms is a float', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({ prompt: 'Hi', model: { name: 'gpt-4o', timeout_ms: 1.5 } }),
+    ).toThrow();
+  });
+
+  // max_retries validation
+  it('throws when max_retries is negative', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({ prompt: 'Hi', model: { name: 'gpt-4o', max_retries: -1 } }),
+    ).toThrow();
+  });
+
+  it('throws when max_retries is a float', () => {
+    expect(() =>
+      ValidatedCommandSchema.parse({ prompt: 'Hi', model: { name: 'gpt-4o', max_retries: 1.5 } }),
+    ).toThrow();
   });
 });
 

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -11,6 +11,8 @@ const ModelSpecSchema = z.preprocess(
     provider: z.enum(PROVIDER_VALUES).optional(),
     temperature: z.number().optional(),
     max_tokens: z.number().int().optional(),
+    timeout_ms: z.number().int().positive().optional(),
+    max_retries: z.number().int().min(0).optional(),
   })
 );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,10 @@ export interface ModelSpec {
   provider?: ProviderName;
   temperature?: number;
   max_tokens?: number;
+  /** Maximum time in milliseconds to wait for the API call to complete. Defaults to 60000 (60s). */
+  timeout_ms?: number;
+  /** Maximum number of retries on retryable errors. Defaults to 3. */
+  max_retries?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements configurable API call timeout and max retry count per YAML command (issue #31).

## Changes

### New YAML fields in `model` section
```yaml
model:
  name: gpt-4o
  timeout_ms: 30000   # optional, defaults to 60000 (60s)
  max_retries: 1      # optional, defaults to 3
```

### Implementation
- **`src/types/index.ts`** — added `timeout_ms?: number` and `max_retries?: number` to `ModelSpec`
- **`src/parser/schema.ts`** — Zod validation for new fields (positive int, non-negative int)
- **4 adapters** (openai / anthropic / gemini / ollama) — timeout via `Promise.race` + `setTimeout`; retry count from `ModelSpec` instead of hardcoded constant
- **Tests** — timeout and custom `max_retries` tests added to all 4 adapters (3 new tests each)
- **`docs/spec-draft.md`** — ModelSpec appendix updated
- **`README.md`** — Cost & Rate Limit Protection section added

## Acceptance Criteria

- [x] `call()`/`callStreaming()` abort after `timeout_ms` ms with readable ExecutorError
- [x] `max_retries` controls retry count per command
- [x] No infinite retry / infinite wait possible
- [x] README documents cost risk
- [x] Unit tests cover timeout and custom retry count (abnormal path)

Closes #31