### PR TITLE
ci: npm auto-publish workflow with Provenance (closes #28)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # yali — YAML LLM Interface
 
-[![CI](https://github.com/your-org/yali/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/yali/actions/workflows/ci.yml)
+[![CI](https://github.com/shira022/yali/actions/workflows/ci.yml/badge.svg)](https://github.com/shira022/yali/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js 20+](https://img.shields.io/badge/Node.js-20%2B-green.svg)](https://nodejs.org/)
 
@@ -29,12 +29,26 @@
 ### インストール
 
 ```bash
-git clone https://github.com/your-org/yali.git
+# 推奨: npm からインストール
+npm install -g yali
+```
+
+インストールせずに実行する場合:
+```bash
+npx yali --help
+```
+
+<details>
+<summary>ソースからビルドする場合</summary>
+
+```bash
+git clone https://github.com/shira022/yali.git
 cd yali
 npm install
 npm run build
 npm link
 ```
+</details>
 
 ### 30秒サンプル
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yali
 
-[![CI](https://img.shields.io/github/actions/workflow/status/your-org/yali/ci.yml?label=CI&style=flat-square)](https://github.com/your-org/yali/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/shira022/yali/ci.yml?label=CI&style=flat-square)](https://github.com/shira022/yali/actions)
 [![npm](https://img.shields.io/npm/v/yali?style=flat-square)](https://www.npmjs.com/package/yali)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
@@ -29,12 +29,26 @@
 ### Install
 
 ```bash
-git clone https://github.com/your-org/yali.git
+# Recommended: install from npm
+npm install -g yali
+```
+
+Or run without installing:
+```bash
+npx yali --help
+```
+
+<details>
+<summary>Build from source</summary>
+
+```bash
+git clone https://github.com/shira022/yali.git
 cd yali
 npm install
 npm run build
-npm link          # makes `yali` available globally
+npm link
 ```
+</details>
 
 ### 30-second example
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "yali",
   "version": "0.1.0",
   "description": "YAML LLM Interface — Define LLM commands in YAML and run them as a CLI tool",
+  "files": ["dist"],
   "bin": {
     "yali": "./dist/cli.js"
   },


### PR DESCRIPTION
## Summary

Implements automated npm publishing via GitHub Actions when a `v*.*.*` tag is pushed.

## Changes

- **`.github/workflows/publish.yml`** (new) — tag-triggered workflow: build → test → `npm publish --provenance` → GitHub Release
- **`environment: npm-publish`** added to publish job — scopes NPM_TOKEN to environment secret; records deployment history in GitHub Deployments page
- **`package.json`** — added `"files": ["dist"]` to include only compiled output in the npm package
- **`README.md`** — npm-first install instructions (`npm install -g yali` / `npx yali`), fixed `your-org` → `shira022` in badge URLs
- **`README.ja.md`** — same updates in Japanese

## Security Model

### Token protection (2 layers)

| Layer | Setting | What it prevents |
|---|---|---|
| **Layer 1** | `environment: npm-publish` in workflow | NPM_TOKEN scoped to environment only |
| **Layer 2** ★ | Environment → Deployment branches/tags restricted to `v*.*.*` tags | Unauthorized workflows cannot access NPM_TOKEN even with `environment: npm-publish` |

### Required deployments — intentionally not used

GitHub's `Required deployments` in a tag Ruleset requires a prior deployment to succeed *before* the tag can be pushed. This works for branch protection (e.g., require staging deployment before merging to main), but would require adding a deployment step to `ci.yml` (out of scope for this issue). Documented in Issue #28 as a future enhancement.

## Setup Steps (for maintainer)

See the comment on Issue #28 for full instructions:
1. Create `npm-publish` GitHub Environment
2. Restrict Deployment branches/tags to `v*.*.*` tag pattern
3. Move `NPM_TOKEN` from Repository secrets to Environment secrets

## How to Release

```bash
git tag v0.1.0
git push origin v0.1.0
```

## Checklist

- [x] `.github/workflows/publish.yml` created
- [x] `environment: npm-publish` added (environment-scoped NPM_TOKEN)
- [x] `npm publish --provenance` with `id-token: write`
- [x] GitHub Release auto-created with generated notes
- [x] `package.json` has `"files": ["dist"]`
- [x] README updated with npm install instructions
- [x] Existing CI workflows unchanged
- [x] All 311 tests pass, lint clean
- [x] Issue #28 has Environment setup guide comment

Closes #28