### PR TITLE
ci: pin GitHub Actions to SHA + update to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -35,6 +35,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Pins all GitHub Actions workflow steps to full commit SHAs to protect against supply chain attacks (tag hijacking), and updates to the latest major versions.

## Security Motivation

Using floating tags like `@v4` allows the tag owner (or an attacker who compromises the account) to silently replace the tag with malicious code. Pinning to a full SHA guarantees that the exact reviewed code runs every time.

**Risk level by action:**
- `softprops/action-gh-release` — 🔴 third-party, has access to `NPM_TOKEN` → highest priority
- `actions/checkout` / `actions/setup-node` — 🟡 GitHub-official, lower risk but still best practice

## Changes

| File | Action | Before | After |
|---|---|---|---|
| `publish.yml` | actions/checkout | `@v4` | `@de0fac2e` (v6.0.2) |
| `publish.yml` | actions/setup-node | `@v4` | `@48b55a01` (v6.4.0) |
| `publish.yml` | softprops/action-gh-release | `@v2` | `@b4309332` (v3.0.0) |
| `ci.yml` | actions/checkout | `@v4` | `@de0fac2e` (v6.0.2) |
| `ci.yml` | actions/setup-node | `@v4` | `@48b55a01` (v6.4.0) |
| `.github/dependabot.yml` | — | (new) | Weekly auto-update PRs for Actions SHAs |

## Dependabot

Added `.github/dependabot.yml` to automatically open weekly PRs when newer versions are released, keeping the pinned SHAs current with minimal manual effort.

## Checklist

- [x] All Actions pinned to full commit SHA with version comment
- [x] Updated to latest major versions (v6 for checkout/setup-node, v3 for gh-release)
- [x] `.github/dependabot.yml` added for weekly auto-update
- [x] All 311 tests pass, lint clean