### PR TITLE
ci: exempt Dependabot PRs from multi-agent review flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS — defines who must approve pull requests
+#
+# All files require review from @shira022.
+# This ensures require_code_owner_reviews in branch protection is enforced.
+* @shira022
+
+# CODEOWNERS itself also requires @shira022 approval (self-protecting)
+.github/CODEOWNERS @shira022

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: weekly
     commit-message:
       prefix: ci
+    rebase-strategy: auto

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -41,13 +41,24 @@ jobs:
           MISSING=()
           PASS=true
 
-          # Check for 'approved' label (added by AI evaluator)
-          if has_label "approved"; then
-            echo "✅ 'approved' label present (AI review passed)"
-          else
-            echo "❌ 'approved' label missing (AI review not yet complete)"
-            MISSING+=("approved label (AI review)")
-            PASS=false
+          # Dependabot PRs are exempt from the AI review requirement.
+          # They only need a human LGTM label to pass the merge gate.
+          ACTOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          IS_DEPENDABOT=false
+          if [ "$ACTOR" = "app/dependabot" ]; then
+            IS_DEPENDABOT=true
+            echo "ℹ️ Dependabot PR detected — skipping 'approved' label check"
+          fi
+
+          if [ "$IS_DEPENDABOT" = "false" ]; then
+            # Check for 'approved' label (added by AI evaluator)
+            if has_label "approved"; then
+              echo "✅ 'approved' label present (AI review passed)"
+            else
+              echo "❌ 'approved' label missing (AI review not yet complete)"
+              MISSING+=("approved label (AI review)")
+              PASS=false
+            fi
           fi
 
           # Check for sufficient 'LGTM' labels (added manually by maintainers)
@@ -62,7 +73,11 @@ jobs:
 
           if [ "$PASS" = "true" ]; then
             echo ""
-            echo "🟢 Merge gate passed — PR has all required labels."
+            if [ "$IS_DEPENDABOT" = "true" ]; then
+              echo "🟢 Merge gate passed — Dependabot PR with LGTM label."
+            else
+              echo "🟢 Merge gate passed — PR has all required labels."
+            fi
             exit 0
           else
             echo ""

--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -21,6 +21,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Dependabot PRs are exempt from the multi-agent review flow.
+          # They only require a human LGTM label to pass the merge gate.
+          ACTOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          if [ "$ACTOR" = "app/dependabot" ]; then
+            echo "Dependabot PR detected — skipping review-needed label (exempt from AI review)"
+            exit 0
+          fi
+
           # Fetch current labels on the PR
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name]')
           echo "Current labels: $LABELS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,18 @@ The `pr-review-trigger.yml` and `merge-gate.yml` workflows:
 
 All AI processing happens on contributors' local machines or cloud agents — not in GitHub Actions runners.
 
+### Dependabot PRs
+
+Dependabot PRs (automated dependency updates) are **exempt from the AI review flow**.
+
+- The `review-needed` label is **not** added to Dependabot PRs
+- The `approved` label is **not** required for Dependabot PRs
+- Only a human `LGTM` label is needed to pass the merge gate
+
+This is intentional: automated dependency bumps (e.g., GitHub Actions version updates) do not benefit from the AI review pipeline, which is designed for source code changes.
+
+> **For maintainers**: review Dependabot PRs manually, add the `LGTM` label if the change looks safe, and merge.
+
 ### Label Reference
 
 | Label | Added By | Meaning |


### PR DESCRIPTION
## Summary

This PR exempts Dependabot dependency update PRs from the multi-agent AI review pipeline, which is designed for source code changes.

## Changes

### Workflow changes
- **`pr-review-trigger.yml`**: Detect Dependabot PRs (author = `app/dependabot`) and skip adding the `review-needed` label
- **`merge-gate.yml`**: Detect Dependabot PRs and skip the `approved` label check — only `LGTM` is required

### Dependabot configuration
- **`dependabot.yml`**: Add `rebase-strategy: auto` so Dependabot automatically rebases when main advances (resolves `CI / test — Expected — Waiting for status to be reported` that occurs with `strict: true` branch protection)

### Security
- **`.github/CODEOWNERS`**: Create CODEOWNERS file defining `@shira022` as code owner for all files. This makes the existing `require_code_owner_reviews: true` branch protection setting actually functional.

### Documentation
- **`CONTRIBUTING.md`**: Add a "Dependabot PRs" section explaining the exemption to other contributors

## Why

Dependabot PRs (e.g., GitHub Actions version bumps) are automated and low-risk. Running the full 3-reviewer multi-agent pipeline for a 1-line CI configuration change is unnecessary overhead.

The `approved` label semantically means "AI review has been conducted and passed". Automatically adding it without review would be misleading. Instead, Dependabot PRs are exempted from the requirement entirely.

## Review notes

This PR itself goes through the standard multi-agent review flow as it modifies CI/CD configuration.