### PR TITLE
ci: pin actions/checkout to SHA in merge-gate workflow

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout (for config file)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check required labels
         env:


### PR DESCRIPTION
## Summary

Replace `actions/checkout@v4` with the SHA-pinned `v6.0.2` in `merge-gate.yml`, consistent with `ci.yml`.

## Changes

```diff
- uses: actions/checkout@v4
+ uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

## Why

- **Supply chain security**: SHA pinning ensures the exact commit is used, preventing tag mutation attacks
- **Consistency**: `ci.yml` already uses the same SHA-pinned form; this aligns `merge-gate.yml`
- **v6 upgrade**: Supersedes Dependabot PR #46 (closed), which suggested `@v6` without pinning

Closes #46