### PR TITLE
docs: fix scoped package name and add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 shira022
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 shira022
+Copyright (c) 2026 shira022
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.ja.md
+++ b/README.ja.md
@@ -122,3 +122,5 @@ Options:
 ## ライセンス
 
 [MIT](LICENSE)
+
+サードパーティライブラリのライセンス表示は [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES) を参照してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,7 +35,7 @@ npm install -g @shira022/yali
 
 インストールせずに実行する場合:
 ```bash
-npx yali --help
+npx @shira022/yali --help
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # yali
 
 [![CI](https://img.shields.io/github/actions/workflow/status/shira022/yali/ci.yml?label=CI&style=flat-square)](https://github.com/shira022/yali/actions)
-[![npm](https://img.shields.io/npm/v/yali?style=flat-square)](https://www.npmjs.com/package/yali)
+[![npm](https://img.shields.io/npm/v/%40shira022%2Fyali?style=flat-square)](https://www.npmjs.com/package/@shira022/yali)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
 **YAML LLM Interface** — define LLM commands in YAML, run them from the terminal.
@@ -35,7 +35,7 @@ npm install -g @shira022/yali
 
 Or run without installing:
 ```bash
-npx yali --help
+npx @shira022/yali --help
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -131,3 +131,5 @@ Contributions are welcome! Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** fo
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.
+
+Third-party dependency licenses are listed in [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES).

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,288 @@
+# Third-Party Notices
+
+yali includes the following third-party packages. Their licenses and copyright notices are reproduced below.
+
+---
+
+## Apache License 2.0
+
+The following packages are distributed under the Apache License 2.0:
+
+- **openai** (v4.104.0) — Copyright OpenAI. https://github.com/openai/openai-node
+- **@google/generative-ai** (v0.24.1) — Copyright Google LLC. https://github.com/google/generative-ai-js
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 OpenAI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+---
+
+## MIT License
+
+The following packages are distributed under the MIT License:
+
+### @anthropic-ai/sdk (v0.90.0)
+
+https://github.com/anthropics/anthropic-sdk-typescript
+
+Copyright 2023 Anthropic, PBC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+### js-yaml (v4.1.1)
+
+https://github.com/nodeca/js-yaml
+
+(The MIT License)
+
+Copyright (C) 2011-2015 by Vitaly Puzrin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---
+
+### zod (v3.25.76)
+
+https://github.com/colinhacks/zod
+
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/adr/0001-language-choice.md
+++ b/docs/adr/0001-language-choice.md
@@ -34,8 +34,8 @@ See [`docs/spec-draft.md`](../spec-draft.md) for the full specification.
 | `ValidatedCommand` type definition | ◎ `interface`/type system maps naturally |
 | Pure-function Renderer | ◎ Functional style is idiomatic |
 | UNIX pipe / stdin·stdout | ○ `process.stdin` works well |
-| Single-binary distribution | △ Requires `pkg` or similar; `npx yali` is practical |
-| OSS distribution | ◎ `npm publish` / `npx yali` — broad reach |
+| Single-binary distribution | △ Requires `pkg` or similar; `npx @shira022/yali` is practical |
+| OSS distribution | ◎ `npm publish` / `npx @shira022/yali` — broad reach |
 | Testing | ◎ Vitest/Jest, excellent for pure-function unit tests |
 
 ### Option B: Go
@@ -84,7 +84,7 @@ See [`docs/spec-draft.md`](../spec-draft.md) for the full specification.
 
 3. **Agents SDK — full parity**: As of June 2025, the OpenAI TypeScript Agents SDK has reached full feature parity with Python. Multi-step orchestration and streaming can be implemented at the SDK level rather than building on raw REST calls, which would be required in Go.
 
-4. **OSS distribution via npm**: Publishing to npm and supporting `npx yali` makes the tool immediately accessible to a wide developer audience without any environment setup. This aligns with the goal of broad OSS adoption.
+4. **OSS distribution via npm**: Publishing to npm and supporting `npx @shira022/yali` makes the tool immediately accessible to a wide developer audience without any environment setup. This aligns with the goal of broad OSS adoption.
 
 5. **Streaming is idiomatic**: `for await...of` async iteration over streaming responses is natural TypeScript, matching the feel of the rest of the codebase.
 
@@ -92,7 +92,7 @@ See [`docs/spec-draft.md`](../spec-draft.md) for the full specification.
 
 ## Trade-offs and Concerns
 
-- **Single-binary distribution**: Go produces a standalone binary via `go build` with no runtime dependency. TypeScript requires Node.js on the user's machine. `npx yali` mitigates this for the npm ecosystem, but distributing via Homebrew or as a self-contained binary requires additional tooling (e.g., `@vercel/pkg`).
+- **Single-binary distribution**: Go produces a standalone binary via `go build` with no runtime dependency. TypeScript requires Node.js on the user's machine. `npx @shira022/yali` mitigates this for the npm ecosystem, but distributing via Homebrew or as a self-contained binary requires additional tooling (e.g., `@vercel/pkg`).
 
 - **UNIX pipe robustness**: Go's standard library handles `stdin`/`stdout`/pipe and exit-code management more robustly than Node.js. This is an area that will require careful implementation in the Executor layer.
 

--- a/docs/adr/0003-npm-distribution-strategy.md
+++ b/docs/adr/0003-npm-distribution-strategy.md
@@ -16,8 +16,8 @@ Additionally, `yali` is a **project-agnostic, cross-project general-purpose CLI*
 
 When implementing `package.json` for `yali`, the following design decisions were made but not yet recorded as an ADR:
 
-- `npm install -g yali` — for developers who use `yali` daily
-- `npx yali` — for CI pipelines and spot usage (no prior install required)
+- `npm install -g @shira022/yali` — for developers who use `yali` daily
+- `npx @shira022/yali` — for CI pipelines and spot usage (no prior install required)
 - The `bin` field in `package.json` automatically enables both patterns
 
 ---
@@ -26,7 +26,7 @@ When implementing `package.json` for `yali`, the following design decisions were
 
 ### Option A: `npx`-only support
 
-Distribute `yali` without encouraging global installation. Users always run `npx yali run ...`.
+Distribute `yali` without encouraging global installation. Users always run `npx @shira022/yali run ...`.
 
 | Aspect | Assessment |
 |---|---|
@@ -59,8 +59,8 @@ Support both usage patterns by publishing `yali` to npm with a `bin` field in `p
 
 | Aspect | Assessment |
 |---|---|
-| Daily interactive use | ◎ `npm install -g yali` → persistent `yali` command in PATH |
-| CI / spot usage | ◎ `npx yali run ...` → zero-install, runs latest version |
+| Daily interactive use | ◎ `npm install -g @shira022/yali` → persistent `yali` command in PATH |
+| CI / spot usage | ◎ `npx @shira022/yali run ...` → zero-install, runs latest version |
 | Shell tab-completion | ○ Available after global install |
 | Implementation overhead | ◎ Zero — the `bin` field handles both automatically |
 | Local project install | ✕ Not recommended (see Rationale below) |
@@ -69,13 +69,13 @@ Support both usage patterns by publishing `yali` to npm with a `bin` field in `p
 
 ## Decision
 
-**Publish `yali` to npm with a `bin` field**, supporting both `npm install -g yali` (daily use) and `npx yali` (CI / spot use).
+**Publish `yali` to npm with a `bin` field**, supporting both `npm install -g @shira022/yali` (daily use) and `npx @shira022/yali` (CI / spot use).
 
 The `package.json` `bin` field:
 
 ```json
 {
-  "name": "yali",
+  "name": "@shira022/yali",
   "bin": {
     "yali": "./dist/cli.js"
   }
@@ -104,8 +104,8 @@ This single configuration entry makes both installation methods work automatical
 
 - ✅ Zero additional distribution tooling — `bin` field is sufficient.
 - ✅ Both daily and CI usage patterns are covered with a single `package.json` change.
-- ✅ First-time users can evaluate `yali` immediately via `npx yali --help`.
-- ✅ Power users get a persistent, low-latency command via `npm install -g yali`.
+- ✅ First-time users can evaluate `yali` immediately via `npx @shira022/yali --help`.
+- ✅ Power users get a persistent, low-latency command via `npm install -g @shira022/yali`.
 
 ### Negative / Trade-offs
 


### PR DESCRIPTION
## Summary

Fixes two documentation inconsistencies on the main branch.

### Changes

**Package name unification (`@shira022/yali`)**
- `README.md`: Fix npm badge URL and `npx` command to use scoped name `@shira022/yali`
- `README.ja.md`: Same fixes as README.md
- `docs/adr/0003-npm-distribution-strategy.md`: Update code example and all install/npx commands
- `docs/adr/0001-language-choice.md`: Update descriptive references to `npx @shira022/yali`

**MIT LICENSE file**
- Add `LICENSE` file with standard MIT license text (both READMEs referenced it but the file was missing)

### Notes
- The binary command `yali run ...` is unchanged (defined via the `bin` field in package.json)
- `npx @shira022/yali` is the correct zero-install invocation for the scoped package
