### PR TITLE
ci: simplify npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -27,9 +28,6 @@ jobs:
 
       - name: Test
         run: npm test
-
-      - name: Configure npm registry for OIDC Trusted Publishing
-        run: echo "registry=https://registry.npmjs.org/" >> "$HOME/.npmrc"
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- remove the OIDC Trusted Publishing workaround changes that accumulated on `main`
- restore the simpler npm publish workflow shape that existed before the publish-debugging commits
- keep the branch focused on cleaning `main` before doing the actual `v0.2.0` publish locally

## Why
The recent `main` changes after `0.2.0` were largely attempts to make GitHub Actions publishing work. If the release will be published locally instead, those workflow experiments are noise and should not stay on `main`.

## Scope
- `.github/workflows/publish.yml` only

## Verification
- reviewed diff against `origin/main`
- confirmed this branch only removes the later Trusted Publishing workaround logic
